### PR TITLE
Add .gitignore to exclude configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+sygnal.conf
+gunicorn_config.py
+var/
+sygnal.pid
+sygnal.db


### PR DESCRIPTION
Useful when running the server locally for development.