### PR TITLE
Kill off gcm-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "flask==0.10.1",
         "gevent>=1.0.1",
         "pushbaby>=0.0.6",
-        "gcm-client",
+        "grequests",
     ],
     long_description=read("README.rst"),
 )

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -26,7 +26,7 @@ from .exceptions import PushkinSetupException
 
 logger = logging.getLogger(__name__)
 
-GCM_URL = "http://gcm-http.googleapis.com/gcm/send"
+GCM_URL = "https://gcm-http.googleapis.com/gcm/send"
 MAX_TRIES = 3
 RETRY_DELAY_BASE = 10
 


### PR DESCRIPTION
It doesn't support setting the 'priority' field and offers little to no value over just doing the HTTP pokes ourselves, so... do it ourselves.