### PR TITLE
Change gevent.wait to gevent.sleep

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -151,7 +151,7 @@ class GcmPushkin(Pushkin):
                 except:
                     pass
             logger.info("Retrying in %d seconds", retry_delay)
-            gevent.wait(timeout=retry_delay)
+            gevent.sleep(timeout=retry_delay)
 
         logger.info("Gave up retrying reg IDs: %r", pushkeys)
         return failed


### PR DESCRIPTION
wait without objects means wait for the event loop to finish,
which only makes sense from the main greenlet. We want
gevent.sleep().