### PR TITLE
Don't flatten the content dict in GCM

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -168,13 +168,6 @@ class GcmPushkin(Pushkin):
         if n.prio == 'low':
             data['prio'] = 'normal';
 
-        # Flatten because GCM can't handle nested objects
-        if getattr(n, 'content', None):
-            if "msgtype" in n.content:
-                data['msgtype'] = n.content["msgtype"]
-            if "body" in n.content:
-                data['body'] = n.content["body"]
-
         if getattr(n, 'counts', None):
             data['unread'] = n.counts.unread
             data['missed_calls'] = n.counts.missed_calls


### PR DESCRIPTION
Since the flattening code neglected to delete the original nested
keys, we were sending the body and msgtype twice, so we were
often exceeding the message size limit unnecessarily.

By the looks of it, GCM has in fact always supported nested keys,
contrary to the comment (although the google library on Android
exposes the data dict as Map<String, String>). Vector android
uses content.body (ie. the nested key), so the flattened keys
have never been used (console uses neither).