### PR TITLE
Fix `missed_calls` initialization in `Counts`

### DIFF
--- a/sygnal/__init__.py
+++ b/sygnal/__init__.py
@@ -81,8 +81,8 @@ class Counts:
 
         if 'unread' in raw:
             self.unread = raw['unread']
-        if 'mised_calls' in raw:
-            self.mised_calls = raw['mised_calls']
+        if 'missed_calls' in raw:
+            self.missed_calls = raw['missed_calls']
 
 
 class Notification:


### PR DESCRIPTION
Without this fix, `Counts.missed_calls` always was `None` so that no indicators for missed calls were ever shown.