### PR TITLE
[WIP] MQTT support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "gevent>=1.0.1",
         "pushbaby>=0.0.9",
         "grequests",
+        "paho-mqtt",
     ],
     long_description=read("README.rst"),
 )

--- a/sygnal.conf.sample
+++ b/sygnal.conf.sample
@@ -7,3 +7,7 @@ com.example.myapp.ios.type = apns
 com.example.myapp.ios.certfile = com.example.myApp_prod_APNS.pem
 com.example.myapp.android.type = gcm
 com.example.myapp.android.apiKey = your_api_key_for_gcm
+com.example.myapp.mqtt.type = mqtt
+com.example.myapp.mqtt.broker = mqtt_broker
+com.example.myapp.mqtt.username = mqtt_username
+com.example.myapp.mqtt.password = mqtt_password

--- a/sygnal/__init__.py
+++ b/sygnal/__init__.py
@@ -129,6 +129,24 @@ class Pushkin(object):
     def shutdown(self):
         pass
 
+    @staticmethod
+    def build_data(n):
+        data = {}
+        for attr in ['id', 'type', 'sender', 'room_name', 'room_alias', 'membership',
+                     'sender_display_name', 'content', 'room_id']:
+            if hasattr(n, attr):
+                data[attr] = getattr(n, attr)
+
+        data['prio'] = 'high'
+        if n.prio == 'low':
+            data['prio'] = 'normal';
+
+        if getattr(n, 'counts', None):
+            data['unread'] = n.counts.unread
+            data['missed_calls'] = n.counts.missed_calls
+
+        return data
+
 
 class SygnalContext:
     pass

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -170,25 +170,6 @@ class GcmPushkin(Pushkin):
         logger.info("Gave up retrying reg IDs: %r", pushkeys)
         return failed
 
-    @staticmethod
-    def build_data(n):
-        data = {}
-        for attr in ['id', 'type', 'sender', 'room_name', 'room_alias', 'membership',
-                     'sender_display_name', 'content', 'room_id']:
-            if hasattr(n, attr):
-                data[attr] = getattr(n, attr)
-
-        data['prio'] = 'high'
-        if n.prio == 'low':
-            data['prio'] = 'normal';
-
-        if getattr(n, 'counts', None):
-            data['unread'] = n.counts.unread
-            data['missed_calls'] = n.counts.missed_calls
-
-        return data
-
-
 class CanonicalRegIdStore(object):
 
     TABLE_CREATE_QUERY = """

--- a/sygnal/mqttpushkin.py
+++ b/sygnal/mqttpushkin.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Johannes Oertel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import json
+
+import paho.mqtt.client as mqtt
+
+from . import Pushkin
+from .exceptions import PushkinSetupException
+
+
+logger = logging.getLogger(__name__)
+
+class MqttPushkin(Pushkin):
+    def __init__(self, name):
+        super(MqttPushkin, self).__init__(name)
+
+    def setup(self, ctx):
+        self.broker = self.getConfig('broker')
+        if not self.broker:
+            raise PushkinSetupException("No MQTT broker set in config")
+
+        self.mqtt = mqtt.Client(None)
+        username = self.getConfig('username')
+        password = self.getConfig('password')
+        if username and password:
+            self.mqtt.username_pw_set(username, password)
+        self.mqtt.connect(self.broker)
+        self.mqtt.loop_start()
+
+    def dispatchNotification(self, n):
+        pushkeys = [device.pushkey for device in n.devices if device.app_id == self.name]
+        data = MqttPushkin.build_data(n)
+        json_data = json.dumps(data)
+
+        for pushkey in pushkeys:
+            self.mqtt.publish(pushkey, json_data, 2)
+
+        return []
+
+    def shutdown(self):
+        self.mqtt.disconnect()
+        self.mqtt.loop_stop()


### PR DESCRIPTION
This is a first stab at MQTT support (see #14). I tried it with a local mosquitto as the broker and it basically just works, although it's probably not very robust. Open questions for me are:

- What data exactly should be sent over MQTT? Currently, the code uses the same `build_data` method as `GcmPushkin` did to build a dictionary, dumps it as JSON and publishes it over MQTT.
- Under which topic should a notification be published? Currently, we just publish it to a topic named the same as the pushkey for the device. I could then imagine devices that want to receive the notification to connect to the broker with the pushkey as their client id while the broker should be configured such that clients can only subscribe to topics that match their client id. That way only who knows the pushkey for a specific device can subscribe to the notifications. (I'm not sure if the pushkey is meant to be used like that...)
- Which options should be exposed in `sygnal.conf`? An MQTT broker could run on a different port and most brokers also allow authenticating using a client certificate instead of username and password.

This is my first contact with MQTT so I could be entirely off-track. Thus, I would love to hear from people that have more experience with it. :wink:

@jcgruenhage, @ara4n 