### PR TITLE
Fix GCM push response access to enable logging again

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -108,17 +108,17 @@ class GcmPushkin(Pushkin):
                 logger.error(
                     "%d from server, we have sent something invalid! Error: %r",
                     req.response.status_code,
-                    req.response.json(),
+                    req.response.text,
                 )
                 # permanent failure: give up
-                return failed
+                raise Exception("Invalid request")
             elif req.response.status_code == 401:
                 logger.error(
                     "401 from server! Our API key is invalid? Error: %r",
-                    req.response.json(),
+                    req.response.text,
                 )
                 # permanent failure: give up
-                return failed
+                raise Exception("Not authorized to push")
             elif req.response.status_code / 100 == 2:
                 resp_object = req.response.json()
                 if 'results' not in resp_object:

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -107,15 +107,15 @@ class GcmPushkin(Pushkin):
             elif req.response.status_code == 400:
                 logger.error(
                     "%d from server, we have sent something invalid! Error: %r",
-                    response.status_code,
-                    response.json(),
+                    req.response.status_code,
+                    req.response.json(),
                 )
                 # permanent failure: give up
                 return failed
             elif req.response.status_code == 401:
                 logger.error(
                     "401 from server! Our API key is invalid? Error: %r",
-                    response.json(),
+                    req.response.json(),
                 )
                 # permanent failure: give up
                 return failed


### PR DESCRIPTION
The response from GCM/FCM was referred to wrongly so the operation failed (and could not log) the response. This caused an Exception and therefore a 500 response from sygnal. And this let synapse to try pushing again when (hopefully) the config of sygnal got fixed up again.

This PR aims to enable logging but also return 500 when sygnal got configured wrongly.