### PR TITLE
Fix `local variable 'sygnal' referenced before assignment`

### DIFF
--- a/gunicorn_config.py.sample
+++ b/gunicorn_config.py.sample
@@ -26,17 +26,18 @@ def worker_exit(server, worker):
         # This must be imported inside the hook or it won't find
         # the import
         import sygnal
+        # NB. We obviously need to clean up in the worker, not
+        # the arbiter process. worker_exit runs in the worker
+        # (despite the docs claiming it runs after the worker
+        # has exited)
+        # We use a flask hook to handle the worker setup.
+        # Unfortunately flask doesn't have a shutdown hook
+        # (it's not a standard thing in WSGI).
+        sygnal.shutdown()
+
     except:
         # We swallow this exception because it's generally a completely
         # useless, "No module named sygnal" due to it failing to load
         # the sygnal module because an exception was thrown.
         print("Failed to load sygnal - check your log file")
-    # NB. We obviously need to clean up in the worker, not
-    # the arbiter process. worker_exit runs in the worker
-    # (despite the docs claiming it runs after the worker
-    # has exited)
-    # We use a flask hook to handle the worker setup.
-    # Unfortunately flask doesn't have a shutdown hook
-    # (it's not a standard thing in WSGI).
-    sygnal.shutdown()
 


### PR DESCRIPTION
If sygnal did not start successfully, we'll get an exception when trying to
import it. There's no point attempting to clean it up in that case, and doing
so throws another exception.