### PR TITLE
Fixes release of semaphore in GCM

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -148,7 +148,7 @@ class GcmPushkin(Pushkin):
                 "GCM request failure"
             ) from exception
         finally:
-            await self.connection_semaphore.release()
+            self.connection_semaphore.release()
         response_text = (await readBody(response)).decode()
         return response, response_text
 


### PR DESCRIPTION
I have tested it this time, by filling in some nonsense credentials and receiving the proper 'Not authorised to push' response as might be expected.

Signed-off-by: Olivier Wilkinson (reivilibre) <olivier@librepush.net>