### PR TITLE
Handle unknown and 404 GCM response codes

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -203,7 +203,7 @@ class GcmPushkin(Pushkin):
             )
             # permanent failure: give up
             raise NotificationDispatchException("Not authorised to push")
-        elif 200 <= response.code < 300:
+        elif 200 <= response.code < 300 or response.code == 404:
             try:
                 resp_object = json.loads(response_text)
             except JSONDecodeError:

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -264,7 +264,9 @@ class GcmPushkin(Pushkin):
                         new_pushkeys.append(pushkeys[i])
             return failed, new_pushkeys
         else:
-            raise NotificationDispatchException(f"Unknown GCM response code {response.code}")
+            raise NotificationDispatchException(
+                f"Unknown GCM response code {response.code}"
+            )
 
     async def dispatch_notification(self, n, device, context):
         log = NotificationLoggerAdapter(logger, {"request_id": context.request_id})

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -263,6 +263,8 @@ class GcmPushkin(Pushkin):
                         )
                         new_pushkeys.append(pushkeys[i])
             return failed, new_pushkeys
+        else:
+            raise NotificationDispatchException(f"Unknown GCM response code {response.code}")
 
     async def dispatch_notification(self, n, device, context):
         log = NotificationLoggerAdapter(logger, {"request_id": context.request_id})

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -203,7 +203,11 @@ class GcmPushkin(Pushkin):
             )
             # permanent failure: give up
             raise NotificationDispatchException("Not authorised to push")
-        elif 200 <= response.code < 300 or response.code == 404:
+        elif response.code == 404:
+            # assume they're all failed
+            log.info("Reg IDs %r get 404 response; assuming unregistered", pushkeys)
+            return pushkeys, []
+        elif 200 <= response.code < 300:
             try:
                 resp_object = json.loads(response_text)
             except JSONDecodeError:


### PR DESCRIPTION
Fixes:
```
TypeError

cannot unpack non-iterable NoneType object
```

and throw exceptions to catch any other such instances in the future.