### PR TITLE
Fix typo of `getRawHeaders`

### DIFF
--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -180,7 +180,7 @@ class GcmPushkin(Pushkin):
 
             retry_after = None
 
-            for header_value in response.headers.getRawHeader(
+            for header_value in response.headers.getRawHeaders(
                 b"retry-after", default=[]
             ):
                 retry_after = int(header_value)


### PR DESCRIPTION
Should fix
```
AttributeErrorsygnal.gcmpushkin in _request_dispatch
error 'Headers' object has no attribute 'getRawHeader'
```

Signed-off-by: Olivier Wilkinson (reivilibre) <olivier@librepush.net>