### PR TITLE
Add attr and firebase-admin to setup.py deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ def read(fname):
 
 
 DEPENDENCIES = [
+    "attr>=0.3.1",
+    "firebase-admin>=3.2.0",
     "Twisted>=19.2.1",
     "prometheus_client>=0.7.0,<0.8",
     "aioapns>=1.7",


### PR DESCRIPTION
`attr` and `firebase_admin` are both imported by code in this project. As such we need to update `setup.py` with these dependencies so that they're installed on project setup.

Waiting for #73 to fix linting.