### PR TITLE
Replace occurances of 'assertEquals' with 'assertEqual'

### DIFF
--- a/changelog.d/93.misc
+++ b/changelog.d/93.misc
@@ -1,0 +1,1 @@
+Replace occurances of 'assertEquals' with 'assertEqual' to reduce deprecation noise while running tests.

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -61,7 +61,7 @@ class ApnsTestCase(testutils.TestCase):
         self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
         # Assert
-        self.assertEquals(1, method.call_count)
+        self.assertEqual(1, method.call_count)
         ((notification_req,), _kwargs) = method.call_args
         payload = notification_req.message
 
@@ -84,7 +84,7 @@ class ApnsTestCase(testutils.TestCase):
         self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
         # Assert
-        self.assertEquals(1, method.call_count)
+        self.assertEqual(1, method.call_count)
         ((notification_req,), _kwargs) = method.call_args
         payload = notification_req.message
 
@@ -105,10 +105,10 @@ class ApnsTestCase(testutils.TestCase):
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
         # Assert
-        self.assertEquals(1, method.call_count)
+        self.assertEqual(1, method.call_count)
         ((notification_req,), _kwargs) = method.call_args
 
-        self.assertEquals(
+        self.assertEqual(
             {
                 "room_id": "!slw48wfj34rtnrf:example.com",
                 "aps": {
@@ -127,7 +127,7 @@ class ApnsTestCase(testutils.TestCase):
             notification_req.message,
         )
 
-        self.assertEquals({"rejected": []}, resp)
+        self.assertEqual({"rejected": []}, resp)
 
     def test_rejection(self):
         """
@@ -144,8 +144,8 @@ class ApnsTestCase(testutils.TestCase):
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
         # Assert
-        self.assertEquals(1, method.call_count)
-        self.assertEquals({"rejected": ["spqr"]}, resp)
+        self.assertEqual(1, method.call_count)
+        self.assertEqual({"rejected": ["spqr"]}, resp)
 
     def test_no_retry_on_4xx(self):
         """
@@ -162,8 +162,8 @@ class ApnsTestCase(testutils.TestCase):
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
         # Assert
-        self.assertEquals(1, method.call_count)
-        self.assertEquals(502, resp)
+        self.assertEqual(1, method.call_count)
+        self.assertEqual(502, resp)
 
     def test_retry_on_5xx(self):
         """
@@ -181,4 +181,4 @@ class ApnsTestCase(testutils.TestCase):
 
         # Assert
         self.assertGreater(method.call_count, 1)
-        self.assertEquals(502, resp)
+        self.assertEqual(502, resp)

--- a/tests/test_apnstruncate.py
+++ b/tests/test_apnstruncate.py
@@ -70,7 +70,7 @@ class TruncateTestCase(unittest.TestCase):
         # This shouldn't need to be truncated
         txt = simplestring(20)
         aps = {"alert": txt}
-        self.assertEquals(txt, truncate(payload_for_aps(aps), 256)["aps"]["alert"])
+        self.assertEqual(txt, truncate(payload_for_aps(aps), 256)["aps"]["alert"])
 
     def test_truncate_alert(self):
         """
@@ -79,7 +79,7 @@ class TruncateTestCase(unittest.TestCase):
         overhead = len(json_encode(payload_for_aps({"alert": ""})))
         txt = simplestring(10)
         aps = {"alert": txt}
-        self.assertEquals(
+        self.assertEqual(
             txt[:5], truncate(payload_for_aps(aps), overhead + 5)["aps"]["alert"]
         )
 
@@ -90,7 +90,7 @@ class TruncateTestCase(unittest.TestCase):
         overhead = len(json_encode(payload_for_aps({"alert": {"body": ""}})))
         txt = simplestring(10)
         aps = {"alert": {"body": txt}}
-        self.assertEquals(
+        self.assertEqual(
             txt[:5],
             truncate(payload_for_aps(aps), overhead + 5)["aps"]["alert"]["body"],
         )
@@ -103,7 +103,7 @@ class TruncateTestCase(unittest.TestCase):
         overhead = len(json_encode(payload_for_aps({"alert": {"loc-args": [""]}})))
         txt = simplestring(10)
         aps = {"alert": {"loc-args": [txt]}}
-        self.assertEquals(
+        self.assertEqual(
             txt[:5],
             truncate(payload_for_aps(aps), overhead + 5)["aps"]["alert"]["loc-args"][0],
         )
@@ -117,13 +117,13 @@ class TruncateTestCase(unittest.TestCase):
         txt = simplestring(10)
         txt2 = simplestring(10, 3)
         aps = {"alert": {"loc-args": [txt, txt2]}}
-        self.assertEquals(
+        self.assertEqual(
             txt[:5],
             truncate(payload_for_aps(aps), overhead + 10)["aps"]["alert"]["loc-args"][
                 0
             ],
         )
-        self.assertEquals(
+        self.assertEqual(
             txt2[:5],
             truncate(payload_for_aps(aps), overhead + 10)["aps"]["alert"]["loc-args"][
                 1
@@ -156,7 +156,7 @@ class TruncateTestCase(unittest.TestCase):
         aps = {"alert": txt}
         # NB. The number of characters of the string we get is dependent
         # on the json encoding used.
-        self.assertEquals(
+        self.assertEqual(
             txt[:17], truncate(payload_for_aps(aps), overhead + 20)["aps"]["alert"]
         )
 
@@ -171,7 +171,7 @@ class TruncateTestCase(unittest.TestCase):
         trunc = truncate(payload_for_aps(aps), overhead + 30)
         # The string is all 4 byte characters so the trunctaed UTF-8 string
         # should be a multiple of 4 bytes long
-        self.assertEquals(len(trunc["aps"]["alert"].encode()) % 4, 0)
+        self.assertEqual(len(trunc["aps"]["alert"].encode()) % 4, 0)
         # NB. The number of characters of the string we get is dependent
         # on the json encoding used.
-        self.assertEquals(txt[:7], trunc["aps"]["alert"])
+        self.assertEqual(txt[:7], trunc["aps"]["alert"])

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -70,8 +70,8 @@ class GcmTestCase(testutils.TestCase):
 
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
-        self.assertEquals(resp, {"rejected": []})
-        self.assertEquals(gcm.num_requests, 1)
+        self.assertEqual(resp, {"rejected": []})
+        self.assertEqual(gcm.num_requests, 1)
 
     def test_rejected(self):
         """
@@ -85,8 +85,8 @@ class GcmTestCase(testutils.TestCase):
 
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
-        self.assertEquals(resp, {"rejected": ["spqr"]})
-        self.assertEquals(gcm.num_requests, 1)
+        self.assertEqual(resp, {"rejected": ["spqr"]})
+        self.assertEqual(gcm.num_requests, 1)
 
     def test_regenerated_id(self):
         """
@@ -101,7 +101,7 @@ class GcmTestCase(testutils.TestCase):
 
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
-        self.assertEquals(resp, {"rejected": []})
+        self.assertEqual(resp, {"rejected": []})
 
         gcm.preload_with_response(
             200, {"results": [{"registration_id": "spqr_new", "message_id": "msg43"}]}
@@ -109,10 +109,10 @@ class GcmTestCase(testutils.TestCase):
 
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
-        self.assertEquals(gcm.last_request_body["to"], "spqr_new")
+        self.assertEqual(gcm.last_request_body["to"], "spqr_new")
 
-        self.assertEquals(resp, {"rejected": []})
-        self.assertEquals(gcm.num_requests, 2)
+        self.assertEqual(resp, {"rejected": []})
+        self.assertEqual(gcm.num_requests, 2)
 
     def test_batching(self):
         """
@@ -134,9 +134,9 @@ class GcmTestCase(testutils.TestCase):
             self._make_dummy_notification([DEVICE_EXAMPLE, DEVICE_EXAMPLE2])
         )
 
-        self.assertEquals(resp, {"rejected": []})
-        self.assertEquals(gcm.last_request_body["registration_ids"], ["spqr", "spqr2"])
-        self.assertEquals(gcm.num_requests, 1)
+        self.assertEqual(resp, {"rejected": []})
+        self.assertEqual(gcm.last_request_body["registration_ids"], ["spqr", "spqr2"])
+        self.assertEqual(gcm.num_requests, 1)
 
     def test_batching_individual_failure(self):
         """
@@ -160,9 +160,9 @@ class GcmTestCase(testutils.TestCase):
             self._make_dummy_notification([DEVICE_EXAMPLE, DEVICE_EXAMPLE2])
         )
 
-        self.assertEquals(resp, {"rejected": ["spqr2"]})
-        self.assertEquals(gcm.last_request_body["registration_ids"], ["spqr", "spqr2"])
-        self.assertEquals(gcm.num_requests, 1)
+        self.assertEqual(resp, {"rejected": ["spqr2"]})
+        self.assertEqual(gcm.last_request_body["registration_ids"], ["spqr", "spqr2"])
+        self.assertEqual(gcm.num_requests, 1)
 
     def test_regenerated_failure(self):
         """
@@ -178,7 +178,7 @@ class GcmTestCase(testutils.TestCase):
 
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
-        self.assertEquals(resp, {"rejected": []})
+        self.assertEqual(resp, {"rejected": []})
 
         # imagine there is some non-negligible time between these two,
         # and the device in question is unregistered
@@ -190,9 +190,9 @@ class GcmTestCase(testutils.TestCase):
 
         resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
 
-        self.assertEquals(gcm.last_request_body["to"], "spqr_new")
+        self.assertEqual(gcm.last_request_body["to"], "spqr_new")
 
         # the ID translation needs to be transparent as the homeserver will not
         # make sense of it otherwise.
-        self.assertEquals(resp, {"rejected": ["spqr"]})
-        self.assertEquals(gcm.num_requests, 2)
+        self.assertEqual(resp, {"rejected": ["spqr"]})
+        self.assertEqual(gcm.num_requests, 2)

--- a/tests/test_pushgateway_api_v1.py
+++ b/tests/test_pushgateway_api_v1.py
@@ -100,7 +100,7 @@ class PushGatewayApiV1TestCase(testutils.TestCase):
         Test that devices which are accepted by the Pushkin
         do not lead to a rejection being returned to the homeserver.
         """
-        self.assertEquals(
+        self.assertEqual(
             self._request(self._make_dummy_notification([DEVICE_ACCEPTED])),
             {"rejected": []},
         )
@@ -110,7 +110,7 @@ class PushGatewayApiV1TestCase(testutils.TestCase):
         Test that devices which are rejected by the Pushkin
         DO lead to a rejection being returned to the homeserver.
         """
-        self.assertEquals(
+        self.assertEqual(
             self._request(self._make_dummy_notification([DEVICE_REJECTED])),
             {"rejected": [DEVICE_REJECTED["pushkey"]]},
         )
@@ -121,7 +121,7 @@ class PushGatewayApiV1TestCase(testutils.TestCase):
         are the only ones to have a rejection returned to the homeserver,
         even if other devices feature in the request.
         """
-        self.assertEquals(
+        self.assertEqual(
             self._request(
                 self._make_dummy_notification([DEVICE_REJECTED, DEVICE_ACCEPTED])
             ),
@@ -132,7 +132,7 @@ class PushGatewayApiV1TestCase(testutils.TestCase):
         """
         Test that bad requests lead to a 400 Bad Request response.
         """
-        self.assertEquals(self._request({}), 400)
+        self.assertEqual(self._request({}), 400)
 
     def test_exceptions_give_500(self):
         """
@@ -140,19 +140,19 @@ class PushGatewayApiV1TestCase(testutils.TestCase):
         response.
         """
 
-        self.assertEquals(
+        self.assertEqual(
             self._request(self._make_dummy_notification([DEVICE_RAISE_EXCEPTION])), 500
         )
 
         # we also check that a successful device doesn't hide the exception
-        self.assertEquals(
+        self.assertEqual(
             self._request(
                 self._make_dummy_notification([DEVICE_ACCEPTED, DEVICE_RAISE_EXCEPTION])
             ),
             500,
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self._request(
                 self._make_dummy_notification([DEVICE_RAISE_EXCEPTION, DEVICE_ACCEPTED])
             ),
@@ -165,19 +165,19 @@ class PushGatewayApiV1TestCase(testutils.TestCase):
         lead to a 502 Bad Gateway response.
         """
 
-        self.assertEquals(
+        self.assertEqual(
             self._request(self._make_dummy_notification([DEVICE_REMOTE_ERROR])), 502
         )
 
         # we also check that a successful device doesn't hide the exception
-        self.assertEquals(
+        self.assertEqual(
             self._request(
                 self._make_dummy_notification([DEVICE_ACCEPTED, DEVICE_REMOTE_ERROR])
             ),
             502,
         )
 
-        self.assertEquals(
+        self.assertEqual(
             self._request(
                 self._make_dummy_notification([DEVICE_REMOTE_ERROR, DEVICE_ACCEPTED])
             ),


### PR DESCRIPTION
The method [has been deprecated](https://docs.python.org/3/library/unittest.html#deprecated-aliases) and was causing a lot of noise in the console. 