### PR TITLE
Fix psycopg2.ProgrammingError

### DIFF
--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -136,8 +136,10 @@ class Sygnal(object):
         if db_name == "psycopg2":
             logger.info("Using postgresql database")
             self.database_engine = "postgresql"
+            args = config["database"].get("args")
+            args.pop('dbfile', None)
             self.database = ConnectionPool(
-                "psycopg2", cp_reactor=self.reactor, **config["database"].get("args"),
+                "psycopg2", cp_reactor=self.reactor, **args,
             )
         elif db_name == "sqlite3":
             logger.info("Using sqlite database")


### PR DESCRIPTION
I had troubles to run the Matrix Sygnal server due to a conflict between the `CONFIG_DEFAULTS` and the own configuration file.
This specific error happens if the configuration file has the database set to psycopg2.
For example:
```yaml
database:
  name: psycopg2
  args:
    host: sygnal-db
    database: postgres
    user: sygnal
    password: changeme
```

Sygnal now merges the `CONFIG_DEFAULTS` with the given configuration and passes the result to the `ConnectionPool`:
```python
        if db_name == "psycopg2":
            logger.info("Using postgresql database")
            self.database_engine = "postgresql"
            self.database = ConnectionPool(
                "psycopg2", cp_reactor=self.reactor, **config["database"].get("args"),
            )
```
The final configuration now looks like this:
```
{'dbfile': 'sygnal.db', 'host': 'sygnal-db', 'database': 'postgres', 'user': 'sygnal', 'password': 'changeme'}
```
As you can see, even though I haven't the `dbfile` setting in my configuration file, Sygnal injected the `dbfile` key which results in a crash on the server side:
```
psycopg2.ProgrammingError: invalid dsn: invalid connection option "dbfile"
```
My solution might not be the best but it solved my error. 
It might be a good idea to write a proper solution but I am not a Python expert.