### PR TITLE
Remove device token base64 decoding

### DIFF
--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import base64
 import logging
 import os
 from uuid import uuid4
@@ -142,10 +141,8 @@ class ApnsPushkin(Pushkin):
         log.info(f"Sending as APNs-ID {notif_id}")
         span.set_tag("apns_id", notif_id)
 
-        device_token = base64.b64decode(device.pushkey).hex()
-
         request = NotificationRequest(
-            device_token=device_token,
+            device_token=device.pushkey,
             message=shaved_payload,
             priority=prio,
             notification_id=notif_id,


### PR DESCRIPTION
We had troubles to send push notifications through the Apple Push Notification Service. We kept getting the error `BadDeviceToken`.
It turned out that the Sygnal server receives the `pushkey` not in base64 from Matrix Synapse. We debugged this by adding a `print(device.pushkey)` in the `_dispatch_request` method.

After removing the base64 decoding, we finally received a push notification.

The Matrix Synapse source code seems also to verify that. I could not find any line indicating that the pushkey is sent in encoded form. Maybe I am missing something. Feel free to correct me 👍 .
```python
d = {
    "notification": {
        "id": event.event_id,  # deprecated: remove soon
        "event_id": event.event_id,
        "room_id": event.room_id,
        "type": event.type,
        "sender": event.user_id,
        "counts": {  # -- we don't mark messages as read yet so
            # we have no way of knowing
            # Just set the badge to 1 until we have read receipts
            "unread": badge,
            # 'missed_calls': 2
        },
        "devices": [
            {
                "app_id": self.app_id,
                "pushkey": self.pushkey,
                "pushkey_ts": long(self.pushkey_ts / 1000),
                "data": self.data_minus_url,
                "tweaks": tweaks,
            }
        ],
    }
}
```
[synapse/push/httppusher.py#L349](https://github.com/matrix-org/synapse/blob/9c1b83b0078aa9cc1bb902e14d3f7302625ba099/synapse/push/httppusher.py#L349)