### PR TITLE
Report the certificate expiration as a prometheus metric.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ _trial_temp*
 
 /.idea
 /.eggs
+/*.egg-info
 /build
 /dist

--- a/changelog.d/106.feature
+++ b/changelog.d/106.feature
@@ -1,0 +1,1 @@
+Report the APNs certificate expiry as a prometheus metric.

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Twisted>=19.2.1",
         "prometheus_client>=0.7.0,<0.8",
         "aioapns>=1.7",
+        "pyOpenSSL>=17.5.0",
         "pyyaml>=5.1.1",
         "service_identity>=18.1.0",
         "jaeger-client>=4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "Twisted>=19.2.1",
         "prometheus_client>=0.7.0,<0.8",
         "aioapns>=1.7",
-        "pyOpenSSL>=17.5.0",
+        "cryptography>=2.1.4",
         "pyyaml>=5.1.1",
         "service_identity>=18.1.0",
         "jaeger-client>=4.0.0",

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -148,7 +148,7 @@ class ApnsPushkin(Pushkin):
 
         def report_expiry():
             seconds_left = int((expiration_date - datetime.utcnow()).total_seconds())
-            CERTIFICATE_EXPIRATION_GAUGE.set(seconds_left)
+            CERTIFICATE_EXPIRATION_GAUGE.labels(pushkin=self.name).set(seconds_left)
 
         # Report the metric every 60 seconds.
         looper = LoopingCall(report_expiry)

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -54,7 +54,7 @@ RESPONSE_STATUS_CODES_COUNTER = Counter(
 )
 
 CERTIFICATE_EXPIRATION_GAUGE = Gauge(
-    "sygnal_cert_expiry",
+    "sygnal_client_cert_expiry",
     "The expiry date of the client certificate in seconds since the epoch",
     labelnames=["pushkin"],
 )

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -146,9 +146,10 @@ class ApnsPushkin(Pushkin):
         expiration_date = datetime.strptime(
             x509.get_notAfter().decode(), "%Y%m%d%H%M%SZ"
         )
-        # Convert the expiration time to seconds since the epoch.
-        epoch_time = int((expiration_date - datetime(1970, 1, 1)).total_seconds())
-        CERTIFICATE_EXPIRATION_GAUGE.labels(pushkin=self.name).set(epoch_time)
+        # Report the expiration time as seconds since the epoch.
+        CERTIFICATE_EXPIRATION_GAUGE.labels(pushkin=self.name).set(
+            expiration_date.timestamp()
+        )
 
     async def _dispatch_request(self, log, span, device, shaved_payload, prio):
         """

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -144,7 +144,9 @@ class ApnsPushkin(Pushkin):
 
         x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
         # Convert from a string to a datetime object.
-        expiration_date = datetime.strptime(x509.get_notAfter(), "%Y%m%d%H%M%SZ")
+        expiration_date = datetime.strptime(
+            x509.get_notAfter().decode(), "%Y%m%d%H%M%SZ"
+        )
 
         def report_expiry():
             seconds_left = int((expiration_date - datetime.utcnow()).total_seconds())

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -54,7 +54,7 @@ RESPONSE_STATUS_CODES_COUNTER = Counter(
 )
 
 CERTIFICATE_EXPIRATION_GAUGE = Gauge(
-    "sygnal_time_to_certificate_expiration",
+    "sygnal_cert_expiry",
     "The expiry date of the client certificate in seconds since the epoch",
     labelnames=["pushkin"],
 )

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -34,6 +34,8 @@ class ApnsTestCase(testutils.TestCase):
 
         # pretend our certificate exists
         patch("os.path.exists", lambda x: x == TEST_CERTFILE_PATH).start()
+        # Since no certificate exists, don't try to read it.
+        patch("sygnal.apnspushkin.ApnsPushkin._report_certificate_expiration").start()
         self.addCleanup(patch.stopall)
 
         super(ApnsTestCase, self).setUp()


### PR DESCRIPTION
This reports the epoch time (in seconds) of the APNs certificate expiry as a prometheus metric. The metric is updated each time the certificate is loaded (so each time sygnal is started).

pyOpenSSL becomes a direct dependency instead of just a transient one via aioapns.

Fixes #103