### PR TITLE
Fix unit tests after merge of #106

### DIFF
--- a/changelog.d/112.feature
+++ b/changelog.d/112.feature
@@ -1,0 +1,1 @@
+Report the APNs certificate expiry as a prometheus metric.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -54,6 +54,8 @@ class HttpTestCase(testutils.TestCase):
 
         # pretend our certificate exists
         patch("os.path.exists", lambda x: x == TEST_CERTFILE_PATH).start()
+        # Since no certificate exists, don't try to read it.
+        patch("sygnal.apnspushkin.ApnsPushkin._report_certificate_expiration").start()
         self.addCleanup(patch.stopall)
 
         super(HttpTestCase, self).setUp()


### PR DESCRIPTION
It seems that merging #106 caused some of the unit tests from #108 to fail. This fixes them by applying the same additional `patch` as #106.