### PR TITLE
Push Payload Changes

### DIFF
--- a/changelog.d/114.feature
+++ b/changelog.d/114.feature
@@ -1,0 +1,1 @@
+Change aps payload to be mutable, include event_id in payload.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -426,7 +426,7 @@ class ApnsPushkin(Pushkin):
             aps["badge"] = badge
 
         if loc_key:
-            aps["content-available"] = 1
+            aps["mutable-content"] = 1
 
         if loc_key is None and badge is None:
             log.info("Nothing to do for alert of type %s", n.type)
@@ -436,6 +436,8 @@ class ApnsPushkin(Pushkin):
 
         if loc_key and n.room_id:
             payload["room_id"] = n.room_id
+        if loc_key and n.event_id:
+            payload["event_id"] = n.event_id
 
         payload["aps"] = aps
 

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -57,7 +57,7 @@ class ApnsTestCase(testutils.TestCase):
         method.return_value = testutils.make_async_magic_mock(
             NotificationResult("notID", "200")
         )
-        self.sygnal.pushkins[PUSHKIN_ID].MAX_JSON_BODY_SIZE = 200
+        self.sygnal.pushkins[PUSHKIN_ID].MAX_JSON_BODY_SIZE = 240
 
         # Act
         self._request(self._make_dummy_notification([DEVICE_EXAMPLE]))
@@ -67,7 +67,7 @@ class ApnsTestCase(testutils.TestCase):
         ((notification_req,), _kwargs) = method.call_args
         payload = notification_req.message
 
-        self.assertLessEqual(len(apnstruncate.json_encode(payload)), 200)
+        self.assertLessEqual(len(apnstruncate.json_encode(payload)), 240)
 
     def test_payload_truncation_test_validity(self):
         """
@@ -113,6 +113,7 @@ class ApnsTestCase(testutils.TestCase):
         self.assertEqual(
             {
                 "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
                 "aps": {
                     "alert": {
                         "loc-key": "MSG_FROM_USER_IN_ROOM_WITH_CONTENT",
@@ -123,7 +124,7 @@ class ApnsTestCase(testutils.TestCase):
                         ],
                     },
                     "badge": 3,
-                    "content-available": 1,
+                    "mutable-content": 1,
                 },
             },
             notification_req.message,

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -119,6 +119,7 @@ class TestCase(unittest.TestCase):
             "notification": {
                 "id": "$3957tyerfgewrf384",
                 "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
                 "type": "m.room.message",
                 "sender": "@exampleuser:matrix.org",
                 "sender_display_name": "Major Tom",


### PR DESCRIPTION
Change `content-available` to `mutable-content` and also add `event_id` in payload if provided. This is intended to enable modifying push notification content on the client side (iOS). For details:

https://github.com/vector-im/riot-ios/issues/2714
