### PR TITLE
Log errors during start-up and fix the default logging config

### DIFF
--- a/changelog.d/122.bugfix
+++ b/changelog.d/122.bugfix
@@ -1,0 +1,1 @@
+Log errors during start-up.

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -97,6 +97,8 @@ log:
       handlers: ["stderr"]
       level: "INFO"
 
+    disable_existing_loggers: false
+
 
   access:
     # Specify whether or not to trust the IP address in the `X-Forwarded-For`


### PR DESCRIPTION
This copies (a slimmed down) [version of the code we use for Synapse](https://github.com/matrix-org/synapse/blob/207b1737ee0acd226359d59ce3b7f7d46111b1c8/synapse/app/homeserver.py#L395-L423) to log errors during start-up.

With this I'm able to get a sane error message if I have a bad config:

```
$ python -m sygnal.sygnal
The following configuration fields are not understood: {'database'}
Error during startup:
Traceback (most recent call last):
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/sygnal/sygnal/sygnal.py", line 218, in start
    port, bind_addresses, pushgateway_api
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 911, in ensureDeferred
    return _cancellableInlineCallbacks(coro)
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
    _inlineCallbacks(None, g, status)
--- <exception caught here> ---
  File "/sygnal/sygnal/sygnal.py", line 218, in start
    port, bind_addresses, pushgateway_api
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/sygnal/sygnal/sygnal.py", line 196, in _make_pushkins_then_start
    "No app IDs are configured. Edit sygnal.yaml to define some."
builtins.RuntimeError: No app IDs are configured. Edit sygnal.yaml to define some.
```

Fixes #121
Fixes #120