### PR TITLE
Display the actual error when a pushkin cannot be created.

### DIFF
--- a/changelog.d/125.misc
+++ b/changelog.d/125.misc
@@ -1,0 +1,1 @@
+Improve logging if a pushkin cannot be created.

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -190,9 +190,10 @@ class Sygnal(object):
             try:
                 self.pushkins[app_id] = await self._make_pushkin(app_id, app_cfg)
             except Exception:
-                raise RuntimeError(
-                    "Failed to load and create pushkin for kind %s", app_cfg["type"]
+                logger.error(
+                    "Failed to load and create pushkin for kind '%s'" % app_cfg["type"]
                 )
+                raise
 
         if len(self.pushkins) == 0:
             raise RuntimeError(


### PR DESCRIPTION
Error handling is hard. 😢 

This is a follow-up to #122 to show the true error if a pushkin cannot be created, e.g. I added the following to my config:

```yaml
apps:
  foobar:
    type: apns
```

And you get a nice(r) error:

```
2020-05-13 08:11:19,573 [69312] INFO  __main__ Using sqlite database
2020-05-13 08:11:19,582 [69312] INFO  __main__ Importing pushkin module: sygnal.apnspushkin
2020-05-13 08:11:19,612 [69312] INFO  __main__ Creating pushkin: ApnsPushkin
2020-05-13 08:11:19,612 [69312] ERROR __main__ Failed to load and create pushkin for kind 'apns'
Error during startup:
Traceback (most recent call last):
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/matrix/sygnal/sygnal/sygnal.py", line 222, in start
    port, bind_addresses, pushgateway_api
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 911, in ensureDeferred
    return _cancellableInlineCallbacks(coro)
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
    _inlineCallbacks(None, g, status)
--- <exception caught here> ---
  File "/matrix/sygnal/sygnal/sygnal.py", line 222, in start
    port, bind_addresses, pushgateway_api
  File "/.virtualenvs/sygnal/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/matrix/sygnal/sygnal/sygnal.py", line 191, in _make_pushkins_then_start
    self.pushkins[app_id] = await self._make_pushkin(app_id, app_cfg)
  File "/matrix/sygnal/sygnal/sygnal.py", line 186, in _make_pushkin
    return await clarse.create(app_name, self, app_config)
  File "/matrix/sygnal/sygnal/notifications.py", line 129, in create
    return cls(name, sygnal, config)
  File "/matrix/sygnal/sygnal/apnspushkin.py", line 111, in __init__
    "You must provide a path to an APNs certificate, or an APNs token."
sygnal.exceptions.PushkinSetupException: You must provide a path to an APNs certificate, or an APNs token.
```

This will help debug #124.