### PR TITLE
Use `default_payload` in Push Payloads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,16 @@ gcm
   to contain the 'Server key', which can be acquired from Firebase Console at:
   ``https://console.firebase.google.com/project/<PROJECT NAME>/settings/cloudmessaging/``
 
+PusherData Configurations
+=======
+
+When calling https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-pushers-set, clients
+can provide a ``default_payload`` data dictionary in ``PusherData``, which will be passed to Sygnal.
+This will be used by Sygnal to have a default data dictionary in the push payload, for both APNS and
+GCM pushers, if provided. Upon the default payload dictionary, Sygnal will make incremental changes.
+This is useful for clients to decide default push payload content. For instance, iOS clients will have
+freedom to use silent/mutable notifications and be able to set some default alert/sound/badge fields.
+
 Running
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Pusher `data` configuration
 =======
 
 The following parameters can be specified in the `data` dictionary which is given when configuring the pusher
-via [POST /_matrix/client/r0/pushers/set](<https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-pushers-set>) :
+via `POST /_matrix/client/r0/pushers/set <https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-pushers-set>`_ :
 
 * ``default_payload``: a dictionary which defines the basic payload to be sent to the notification service.
   Sygnal will merge information specific to the push event into this dictionary. If unset, the empty dictionary is used.

--- a/README.rst
+++ b/README.rst
@@ -68,12 +68,14 @@ gcm
 Pusher `data` configuration
 =======
 
-When calling https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-pushers-set, clients
-can provide a ``default_payload`` data dictionary in ``PusherData``, which will be passed to Sygnal.
-This will be used by Sygnal to have a default data dictionary in the push payload, for both APNS and
-GCM pushers, if provided. Upon the default payload dictionary, Sygnal will make incremental changes.
-This is useful for clients to decide default push payload content. For instance, iOS clients will have
-freedom to use silent/mutable notifications and be able to set some default alert/sound/badge fields.
+The following parameters can be specified in the `data` dictionary which is given when configuring the pusher
+via [POST /_matrix/client/r0/pushers/set](<https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-pushers-set>) :
+
+* ``default_payload``: a dictionary which defines the basic payload to be sent to the notification service.
+  Sygnal will merge information specific to the push event into this dictionary. If unset, the empty dictionary is used.
+
+  This can be useful for clients to specify default push payload content. For instance, iOS clients will have
+  freedom to use silent/mutable notifications and be able to set some default alert/sound/badge fields.
 
 Running
 =======

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ gcm
   to contain the 'Server key', which can be acquired from Firebase Console at:
   ``https://console.firebase.google.com/project/<PROJECT NAME>/settings/cloudmessaging/``
 
-PusherData Configurations
+Pusher `data` configuration
 =======
 
 When calling https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-pushers-set, clients

--- a/changelog.d/127.feature
+++ b/changelog.d/127.feature
@@ -1,1 +1,1 @@
-Add fallback_content handling from push data.
+Add fallback_content check to include alert field in the APNS payload.

--- a/changelog.d/127.feature
+++ b/changelog.d/127.feature
@@ -1,0 +1,1 @@
+Add fallback_content handling from push data.

--- a/changelog.d/127.feature
+++ b/changelog.d/127.feature
@@ -1,1 +1,1 @@
-Add fallback_content check to include alert field in the APNS payload.
+Use default_payload from device data for both APNS and GCM payloads.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -430,7 +430,7 @@ class ApnsPushkin(Pushkin):
         payload = {}
 
         if n.type and device.data:
-            payload = copy.deepcopy(device.data.get("default_payload",{}))
+            payload = copy.deepcopy(device.data.get("default_payload", {}))
 
         payload.setdefault("aps", {})
 

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -428,7 +428,11 @@ class ApnsPushkin(Pushkin):
 
         payload = {}
 
-        if device.data is not None and device.data["default_payload"] is not None:
+        if (
+            n.type is not None
+            and device.data is not None
+            and device.data["default_payload"] is not None
+        ):
             payload = device.data["default_payload"]
 
         if "aps" not in payload:

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -434,9 +434,7 @@ class ApnsPushkin(Pushkin):
         payload.setdefault("aps", {})
 
         if loc_key:
-            if "alert" not in payload["aps"]:
-                payload["aps"]["alert"] = {}
-            payload["aps"]["alert"]["loc-key"] = loc_key
+            payload["aps"].setdefault("alert", {})["loc-key"] = loc_key
 
         if loc_args:
             if "alert" not in payload["aps"]:

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -431,8 +431,7 @@ class ApnsPushkin(Pushkin):
         if n.type and device.data:
             payload = copy.deepcopy(device.data.get("default_payload",{}))
 
-        if "aps" not in payload:
-            payload["aps"] = {}
+        payload.setdefault("aps", {})
 
         if loc_key:
             if "alert" not in payload["aps"]:

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 import asyncio
 import base64
+import copy
 from datetime import timezone
 import logging
 import os

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -428,12 +428,8 @@ class ApnsPushkin(Pushkin):
 
         payload = {}
 
-        if (
-            n.type is not None
-            and device.data is not None
-            and device.data["default_payload"] is not None
-        ):
-            payload = device.data["default_payload"]
+        if n.type and device.data:
+            payload = copy.deepcopy(device.data.get("default_payload",{}))
 
         if "aps" not in payload:
             payload["aps"] = {}

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -301,11 +301,11 @@ class ApnsPushkin(Pushkin):
         if n.counts.missed_calls is not None:
             payload["missed_calls"] = n.counts.missed_calls
 
-        payload["aps"] = {"mutable-content": 1}
         if (
             device.data["fallback_content"] is not None
             and device.data["fallback_content"]
         ):
+            payload["aps"] = {"mutable-content": 1}
             payload["aps"]["alert"] = {"loc-key": "SINGLE_UNREAD", "loc-args": []}
 
         return payload

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -299,6 +299,13 @@ class ApnsPushkin(Pushkin):
         if n.counts.missed_calls is not None:
             payload["missed_calls"] = n.counts.missed_calls
 
+        payload["aps"] = {"mutable-content": 1}
+        if (
+            n.devices[0].data["fallback_content"] is not None
+            and n.devices[0].data["fallback_content"]
+        ):
+            payload["aps"]["alert"] = {"loc-key": "SINGLE_UNREAD", "loc-args": []}
+
         return payload
 
     def _get_payload_full(self, n, log):

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -283,6 +283,8 @@ class ApnsPushkin(Pushkin):
         Constructs a payload for a notification where we know only the event ID.
         Args:
             n: The notification to construct a payload for.
+            device (Device): Device information to which the constructed payload
+            will be sent.
 
         Returns:
             The APNs payload as a nested dicts.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -226,7 +226,7 @@ class ApnsPushkin(Pushkin):
         ) as span_parent:
 
             if n.event_id and not n.type:
-                payload = self._get_payload_event_id_only(n)
+                payload = self._get_payload_event_id_only(n, device)
             else:
                 payload = self._get_payload_full(n, log)
 
@@ -278,7 +278,7 @@ class ApnsPushkin(Pushkin):
                             retry_delay, twisted_reactor=self.sygnal.reactor
                         )
 
-    def _get_payload_event_id_only(self, n):
+    def _get_payload_event_id_only(self, n, device):
         """
         Constructs a payload for a notification where we know only the event ID.
         Args:
@@ -301,8 +301,8 @@ class ApnsPushkin(Pushkin):
 
         payload["aps"] = {"mutable-content": 1}
         if (
-            n.devices[0].data["fallback_content"] is not None
-            and n.devices[0].data["fallback_content"]
+            device.data["fallback_content"] is not None
+            and device.data["fallback_content"]
         ):
             payload["aps"]["alert"] = {"loc-key": "SINGLE_UNREAD", "loc-args": []}
 

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -291,8 +291,8 @@ class ApnsPushkin(Pushkin):
         """
         payload = {}
 
-        if device.data is not None and device.data["default_payload"] is not None:
-            payload = device.data["default_payload"]
+        if device.data:
+            payload.update(device.data.get("default_payload", {}))
 
         if n.room_id:
             payload["room_id"] = n.room_id

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -437,9 +437,7 @@ class ApnsPushkin(Pushkin):
             payload["aps"].setdefault("alert", {})["loc-key"] = loc_key
 
         if loc_args:
-            if "alert" not in payload["aps"]:
-                payload["aps"]["alert"] = {}
-            payload["aps"]["alert"]["loc-args"] = loc_args
+            payload["aps"].setdefault("alert", {})["loc-args"] = loc_args
 
         if badge is not None:
             payload["aps"]["badge"] = badge

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -406,8 +406,8 @@ class GcmPushkin(Pushkin):
         """
         data = {}
 
-        if device.data is not None and device.data["default_payload"] is not None:
-            data = device.data["default_payload"]
+        if device.data:
+            data.update(device.data.get("default_payload", {}))
 
         for attr in [
             "event_id",

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -323,7 +323,7 @@ class GcmPushkin(Pushkin):
 
             inverse_reg_id_mappings = {v: k for (k, v) in reg_id_mappings.items()}
 
-            data = GcmPushkin._build_data(n)
+            data = GcmPushkin._build_data(n, device)
             headers = {
                 b"User-Agent": ["sygnal"],
                 b"Content-Type": ["application/json"],
@@ -393,16 +393,22 @@ class GcmPushkin(Pushkin):
             return failed
 
     @staticmethod
-    def _build_data(n):
+    def _build_data(n, device):
         """
         Build the payload data to be sent.
         Args:
             n: Notification to build the payload for.
+            device (Device): Device information to which the constructed payload
+            will be sent.
 
         Returns:
             JSON-compatible dict
         """
         data = {}
+
+        if device.data is not None and device.data["default_payload"] is not None:
+            data = device.data["default_payload"]
+
         for attr in [
             "event_id",
             "type",

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -181,6 +181,34 @@ class ApnsTestCase(testutils.TestCase):
 
         self.assertEqual({"rejected": []}, resp)
 
+    def test_expected_badge_only_with_default_payload(self):
+        """
+        Tests the expected fallback case: a good response from APNS means we pass on
+        a good response to the homeserver.
+        """
+        # Arrange
+        method = self.apns_pushkin_snotif
+        method.side_effect = testutils.make_async_magic_mock(
+            NotificationResult("notID", "200")
+        )
+
+        # Act
+        resp = self._request(
+            self._make_dummy_notification_badge_only(
+                [DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD]
+            )
+        )
+
+        # Assert
+        self.assertEqual(1, method.call_count)
+        ((notification_req,), _kwargs) = method.call_args
+
+        self.assertEqual(
+            {"aps": {"badge": 2}}, notification_req.message,
+        )
+
+        self.assertEqual({"rejected": []}, resp)
+
     def test_expected_full_with_default_payload(self):
         """
         Tests the expected fallback case: a good response from APNS means we pass on

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -24,11 +24,18 @@ PUSHKIN_ID = "com.example.apns"
 TEST_CERTFILE_PATH = "/path/to/my/certfile.pem"
 
 DEVICE_EXAMPLE = {"app_id": "com.example.apns", "pushkey": "spqr", "pushkey_ts": 42}
-DEVICE_EXAMPLE_FALLBACK = {
+DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD = {
     "app_id": "com.example.apns",
     "pushkey": "spqr",
     "pushkey_ts": 42,
-    "data": {"fallback_content": True},
+    "data": {
+        "default_payload": {
+            "aps": {
+                "mutable-content": 1,
+                "alert": {"loc-key": "SINGLE_UNREAD", "loc-args": []},
+            }
+        }
+    },
 }
 
 
@@ -130,7 +137,6 @@ class ApnsTestCase(testutils.TestCase):
                         ],
                     },
                     "badge": 3,
-                    "mutable-content": 1,
                 },
             },
             notification_req.message,
@@ -138,7 +144,7 @@ class ApnsTestCase(testutils.TestCase):
 
         self.assertEqual({"rejected": []}, resp)
 
-    def test_expected_fallback(self):
+    def test_expected_event_id_only_with_default_payload(self):
         """
         Tests the expected fallback case: a good response from APNS means we pass on
         a good response to the homeserver.
@@ -151,7 +157,9 @@ class ApnsTestCase(testutils.TestCase):
 
         # Act
         resp = self._request(
-            self._make_dummy_notification_event_id_only([DEVICE_EXAMPLE_FALLBACK])
+            self._make_dummy_notification_event_id_only(
+                [DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD]
+            )
         )
 
         # Assert
@@ -165,6 +173,48 @@ class ApnsTestCase(testutils.TestCase):
                 "unread_count": 2,
                 "aps": {
                     "alert": {"loc-key": "SINGLE_UNREAD", "loc-args": []},
+                    "mutable-content": 1,
+                },
+            },
+            notification_req.message,
+        )
+
+        self.assertEqual({"rejected": []}, resp)
+
+    def test_expected_full_with_default_payload(self):
+        """
+        Tests the expected fallback case: a good response from APNS means we pass on
+        a good response to the homeserver.
+        """
+        # Arrange
+        method = self.apns_pushkin_snotif
+        method.side_effect = testutils.make_async_magic_mock(
+            NotificationResult("notID", "200")
+        )
+
+        # Act
+        resp = self._request(
+            self._make_dummy_notification([DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD])
+        )
+
+        # Assert
+        self.assertEqual(1, method.call_count)
+        ((notification_req,), _kwargs) = method.call_args
+
+        self.assertEqual(
+            {
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "aps": {
+                    "alert": {
+                        "loc-key": "MSG_FROM_USER_IN_ROOM_WITH_CONTENT",
+                        "loc-args": [
+                            "Major Tom",
+                            "Mission Control",
+                            "I'm floating in a most peculiar way.",
+                        ],
+                    },
+                    "badge": 3,
                     "mutable-content": 1,
                 },
             },

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -34,6 +34,7 @@ DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD = {
     },
 }
 
+
 class TestGcmPushkin(GcmPushkin):
     """
     A GCM pushkin with the ability to make HTTP requests removed and instead
@@ -95,7 +96,9 @@ class GcmTestCase(testutils.TestCase):
             200, {"results": [{"message_id": "msg42", "registration_id": "spqr"}]}
         )
 
-        resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD]))
+        resp = self._request(
+            self._make_dummy_notification([DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD])
+        )
 
         self.assertEqual(resp, {"rejected": []})
         self.assertEqual(gcm.num_requests, 1)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -135,6 +135,16 @@ class TestCase(unittest.TestCase):
             }
         }
 
+    def _make_dummy_notification_event_id_only(self, devices):
+        return {
+            "notification": {
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "counts": {"unread": 2},
+                "devices": devices,
+            }
+        }
+
     def _request(self, payload) -> Union[dict, int]:
         """
         Make a dummy request to the notify endpoint with the specified payload

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -145,6 +145,17 @@ class TestCase(unittest.TestCase):
             }
         }
 
+    def _make_dummy_notification_badge_only(self, devices):
+        return {
+            "notification": {
+                "id": "",
+                "type": None,
+                "sender": "",
+                "counts": {"unread": 2},
+                "devices": devices,
+            }
+        }
+
     def _request(self, payload) -> Union[dict, int]:
         """
         Make a dummy request to the notify endpoint with the specified payload


### PR DESCRIPTION
Add `fallback_content` case handling from push data to include `alert` and `mutable-content` fields in the `aps` dictionary.

Part of vector-im/riot-ios#3325