### PR TITLE
Don't try so hard, APNS — 3 times only, like GCM

### DIFF
--- a/changelog.d/133.misc
+++ b/changelog.d/133.misc
@@ -1,0 +1,1 @@
+Don't try an aioapns connection 4 times per APNS dispatch attempt; do the same as GCM.

--- a/changelog.d/133.misc
+++ b/changelog.d/133.misc
@@ -1,1 +1,1 @@
-Don't try an aioapns connection 4 times per APNS dispatch attempt; do the same as GCM.
+Attempt the same number of retries for both GCM and APNS.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -132,6 +132,9 @@ class ApnsPushkin(Pushkin):
                 raise PushkinSetupException("You must supply topic.")
 
         if certfile is not None:
+            # max_connection_attempts is actually the maximum number of
+            # additional connection attempts, so =0 means try once only
+            # (we will retry at a higher level so not worth doing more here)
             self.apns_client = APNs(
                 client_cert=certfile,
                 use_sandbox=self.use_sandbox,
@@ -140,6 +143,9 @@ class ApnsPushkin(Pushkin):
 
             self._report_certificate_expiration(certfile)
         else:
+            # max_connection_attempts is actually the maximum number of
+            # additional connection attempts, so =0 means try once only
+            # (we will retry at a higher level so not worth doing more here)
             self.apns_client = APNs(
                 key=self.get_config("keyfile"),
                 key_id=self.get_config("key_id"),

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -132,7 +132,11 @@ class ApnsPushkin(Pushkin):
                 raise PushkinSetupException("You must supply topic.")
 
         if certfile is not None:
-            self.apns_client = APNs(client_cert=certfile, use_sandbox=self.use_sandbox)
+            self.apns_client = APNs(
+                client_cert=certfile,
+                use_sandbox=self.use_sandbox,
+                max_connection_attempts=0,
+            )
 
             self._report_certificate_expiration(certfile)
         else:
@@ -142,6 +146,7 @@ class ApnsPushkin(Pushkin):
                 team_id=self.get_config("team_id"),
                 topic=self.get_config("topic"),
                 use_sandbox=self.use_sandbox,
+                max_connection_attempts=0,
             )
 
         # without this, aioapns will retry every second forever.


### PR DESCRIPTION
Signed-off-by: Olivier Wilkinson (reivilibre) <olivier@librepush.net>

This makes a minor difference so that APNS has the same retry schedule as GCM (without extra retries-per-retry).

It may still be doing too much (hopefully mitigated by #132 though)

Fixes #116