### PR TITLE
Add configuration options to allow specifying FCM options

### DIFF
--- a/changelog.d/145.feature
+++ b/changelog.d/145.feature
@@ -1,0 +1,1 @@
+Add ability to configure custom FCM options, which can be useful for using iOS with Firebase.

--- a/changelog.d/145.feature
+++ b/changelog.d/145.feature
@@ -1,1 +1,1 @@
-Add ability to configure custom FCM options, which can be useful for using iOS with Firebase.
+Add the ability to configure custom FCM options, which is necessary for using iOS with Firebase.

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -252,8 +252,16 @@ apps:
   #
   #  # This allows you to specify additional options to send to Firebase.
   #  # See https://firebase.google.com/docs/cloud-messaging/http-server-ref
+  #  # for the exhaustive list of valid options.
   #  # Of particular interest, admins who wish to support iOS apps using Firebase
   #  # probably wish to set content_available, and may need to set mutable_content.
+  #  # (content_available allows your iOS app to be woken up by data messages)
+  #  # and mutable_content allows your notification to be modified by a
+  #  # Notification Service app extension).
+  #  #
+  #  # Do not specify `data`, `priority`, `to` or `registration_ids` as they may
+  #  # be overwritten or lead to an invalid request.
+  #  #
   #  #fcm_options:
   #  #  content_available: true
   #  #  mutable_content: true

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -251,13 +251,15 @@ apps:
   #  #inflight_request_limit: 512
   #
   #  # This allows you to specify additional options to send to Firebase.
-  #  # See https://firebase.google.com/docs/cloud-messaging/http-server-ref
-  #  # for the exhaustive list of valid options.
+  #  #
   #  # Of particular interest, admins who wish to support iOS apps using Firebase
   #  # probably wish to set content_available, and may need to set mutable_content.
-  #  # (content_available allows your iOS app to be woken up by data messages)
+  #  # (content_available allows your iOS app to be woken up by data messages,
   #  # and mutable_content allows your notification to be modified by a
   #  # Notification Service app extension).
+  #  #
+  #  # See https://firebase.google.com/docs/cloud-messaging/http-server-ref
+  #  # for the exhaustive list of valid options.
   #  #
   #  # Do not specify `data`, `priority`, `to` or `registration_ids` as they may
   #  # be overwritten or lead to an invalid request.

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -249,3 +249,11 @@ apps:
   #  # Defaults to 512 if unset.
   #  #
   #  #inflight_request_limit: 512
+  #
+  #  # This allows you to specify additional options to send to Firebase.
+  #  # See https://firebase.google.com/docs/cloud-messaging/http-server-ref
+  #  # Of particular interest, admins who wish to support iOS apps using Firebase
+  #  # probably wish to set content_available, and may need to set mutable_content.
+  #  #fcm_options:
+  #  #  content_available: true
+  #  #  mutable_content: true

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -138,7 +138,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         self.base_request_body: dict = self.get_config("fcm_options", {})
         if not isinstance(self.base_request_body, dict):
             raise PushkinSetupException(
-                "fcm_options, if set, should be a dictionary of options."
+                "Config field fcm_options, if set, must be a dictionary of options"
             )
 
     @classmethod

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -135,6 +135,9 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         if not self.api_key:
             raise PushkinSetupException("No API key set in config")
 
+        # Use the fcm_options config dictionary as a foundation for the body;
+        # this lets the Sygnal admin choose custom FCM options
+        # (e.g. content_available).
         self.base_request_body: dict = self.get_config("fcm_options", {})
         if not isinstance(self.base_request_body, dict):
             raise PushkinSetupException(
@@ -355,8 +358,6 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             # TODO: Implement collapse_key to queue only one message per room.
             failed = []
 
-            # use the base body as a foundation for the body; this lets the
-            # Sygnal admin choose custom FCM options (e.g. content_available).
             body = self.base_request_body.copy()
             body["data"] = data
             body["priority"] = "normal" if n.prio == "low" else "high"

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -96,7 +96,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
     UNDERSTOOD_CONFIG_FIELDS = {
         "type",
         "api_key",
-        "fcm_options"
+        "fcm_options",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     def __init__(self, name, sygnal, config, canonical_reg_id_store):
@@ -137,7 +137,9 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
 
         self.base_request_body: dict = self.get_config("fcm_options", {})
         if not isinstance(self.base_request_body, dict):
-            raise PushkinSetupException("fcm_options, if set, should be a dictionary of options.")
+            raise PushkinSetupException(
+                "fcm_options, if set, should be a dictionary of options."
+            )
 
     @classmethod
     async def create(cls, name, sygnal, config):

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -34,6 +34,7 @@ DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD = {
         }
     },
 }
+DEVICE_EXAMPLE_IOS = {"app_id": "com.example.gcm.ios", "pushkey": "spqr", "pushkey_ts": 42}
 
 
 class TestGcmPushkin(GcmPushkin):
@@ -70,6 +71,14 @@ class GcmTestCase(testutils.TestCase):
         config["apps"]["com.example.gcm"] = {
             "type": "tests.test_gcm.TestGcmPushkin",
             "api_key": "kii",
+        }
+        config["apps"]["com.example.gcm.ios"] = {
+            "type": "tests.test_gcm.TestGcmPushkin",
+            "api_key": "kii",
+            "fcm_options": {
+                "content_available": True,
+                "mutable_content": True
+            }
         }
 
     def test_expected(self):
@@ -227,3 +236,19 @@ class GcmTestCase(testutils.TestCase):
         # make sense of it otherwise.
         self.assertEqual(resp, {"rejected": ["spqr"]})
         self.assertEqual(gcm.num_requests, 2)
+
+    def test_fcm_options(self):
+        """
+        Tests that the config option `fcm_options` allows setting a base layer
+        of options to pass to FCM, for example ones that would be needed for iOS.
+        """
+        gcm = self.sygnal.pushkins["com.example.gcm.ios"]
+        gcm.preload_with_response(
+            200, {"results": [{"registration_id": "spqr_new", "message_id": "msg42"}]}
+        )
+
+        resp = self._request(self._make_dummy_notification([DEVICE_EXAMPLE_IOS]))
+
+        self.assertEqual(resp, {"rejected": []})
+        self.assertEqual(gcm.last_request_body["mutable_content"], True)
+        self.assertEqual(gcm.last_request_body["content_available"], True)

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -34,7 +34,11 @@ DEVICE_EXAMPLE_WITH_DEFAULT_PAYLOAD = {
         }
     },
 }
-DEVICE_EXAMPLE_IOS = {"app_id": "com.example.gcm.ios", "pushkey": "spqr", "pushkey_ts": 42}
+DEVICE_EXAMPLE_IOS = {
+    "app_id": "com.example.gcm.ios",
+    "pushkey": "spqr",
+    "pushkey_ts": 42,
+}
 
 
 class TestGcmPushkin(GcmPushkin):
@@ -75,10 +79,7 @@ class GcmTestCase(testutils.TestCase):
         config["apps"]["com.example.gcm.ios"] = {
             "type": "tests.test_gcm.TestGcmPushkin",
             "api_key": "kii",
-            "fcm_options": {
-                "content_available": True,
-                "mutable_content": True
-            }
+            "fcm_options": {"content_available": True, "mutable_content": True},
         }
 
     def test_expected(self):


### PR DESCRIPTION
This is practically a must-have for anyone who wants to use Firebase with iOS, as content-available is needed to cause an iOS app to wake up from an APNs push.