### PR TITLE
Add 'max_connections' as an understood config field to gcmpushkin

### DIFF
--- a/changelog.d/157.bugfix
+++ b/changelog.d/157.bugfix
@@ -1,1 +1,1 @@
-Fix erroneous warning log line when setting the 'max_connections' option in a GCM app config.
+Fix erroneous warning log line when setting the `max_connections` option in a GCM app config.

--- a/changelog.d/157.bugfix
+++ b/changelog.d/157.bugfix
@@ -1,0 +1,1 @@
+Fix erroneous warning log line when setting the 'max_connections' option in a GCM app config.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -97,6 +97,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         "type",
         "api_key",
         "fcm_options",
+        "max_connections",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     def __init__(self, name, sygnal, config, canonical_reg_id_store):


### PR DESCRIPTION
We were getting the following harmless error in our logs:

```
[...] sygnal.gcmpushkin 109 - WARNING - The following configuration fields are not understood: {'max_connections'}
```

However this option is documented in the sample config:

https://github.com/matrix-org/sygnal/blob/08318c8d10a021fa9f6fcc6d5b8b335d26ded9ae/sygnal.yaml.sample#L245-L247

and used in the codebase:

https://github.com/matrix-org/sygnal/blob/0672a8403115a92e35bd2fe76d74b28976122298/sygnal/gcmpushkin.py#L114-L116

So it seems like we just forgot to add it to this list while adding the option :slightly_smiling_face: 

(If you're wondering why `inflight_request_limit` isn't in this dict either, that's because it's shared across both APNs and GCM pushkin types :)