### PR TITLE
Example - Optionally exit python if limit hit.

### DIFF
--- a/changelog.d/159.misc
+++ b/changelog.d/159.misc
@@ -1,0 +1,1 @@
+Add new config 'crash_on_limit', which can restart the python process if the rate limit is exceeded.y


### PR DESCRIPTION
If the system becomes unstable, then exit rather than continuing - this will allow something like systemd to restart quickly and let us carry on from a known-good situation.