### PR TITLE
Initialise sygnal_inflight_request_limit_drop before it's incremented

### DIFF
--- a/changelog.d/172.bugfix
+++ b/changelog.d/172.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug where the `sygnal_inflight_request_limit_drop` metric would not appear in prometheus until requests were actually dropped.

--- a/sygnal/helper/proxy/proxy_asyncio.py
+++ b/sygnal/helper/proxy/proxy_asyncio.py
@@ -260,9 +260,7 @@ class ProxyingEventLoopWrapper:
     """
 
     def __init__(
-        self,
-        wrapped_loop: asyncio.AbstractEventLoop,
-        proxy_url_str: str,
+        self, wrapped_loop: asyncio.AbstractEventLoop, proxy_url_str: str,
     ):
         """
         Args:

--- a/sygnal/helper/proxy/proxy_asyncio.py
+++ b/sygnal/helper/proxy/proxy_asyncio.py
@@ -260,7 +260,9 @@ class ProxyingEventLoopWrapper:
     """
 
     def __init__(
-        self, wrapped_loop: asyncio.AbstractEventLoop, proxy_url_str: str,
+        self,
+        wrapped_loop: asyncio.AbstractEventLoop,
+        proxy_url_str: str,
     ):
         """
         Args:

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -162,9 +162,8 @@ class ConcurrencyLimitedPushkin(Pushkin):
         # Grab an instance of the dropped request counter given our pushkin name.
         # Note this ensures the counter appears in metrics even if it hasn't yet
         # been incremented.
-        self.dropped_requests_counter = ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(
-            pushkin=name
-        )
+        dropped_requests = ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS
+        self.dropped_requests_counter = dropped_requests.labels(pushkin=name)
 
     async def dispatch_notification(
         self, n: Notification, device: Device, context: "NotificationContext"

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -162,8 +162,8 @@ class ConcurrencyLimitedPushkin(Pushkin):
         # Grab an instance of the dropped request counter given our pushkin name.
         # Note this ensures the counter appears in metrics even if it hasn't yet
         # been incremented.
-        self.dropped_requests_counter = ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(
-            pushkin=name
+        self.dropped_requests_counter = (
+            ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(pushkin=name)
         )
 
     async def dispatch_notification(

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -159,13 +159,18 @@ class ConcurrencyLimitedPushkin(Pushkin):
         )
         self._concurrent_now = 0
 
+        # Grab an instance of the dropped request counter given our pushkin name.
+        # Note this ensures the counter appears in metrics even if it hasn't yet
+        # been incremented.
+        self.dropped_requests_counter = ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(
+            pushkin=name
+        )
+
     async def dispatch_notification(
         self, n: Notification, device: Device, context: "NotificationContext"
     ) -> List[str]:
         if self._concurrent_now >= self._concurrent_limit:
-            ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(
-                pushkin=self.name
-            ).inc()
+            self.dropped_requests_counter.inc()
             raise NotificationDispatchException(
                 "Too many in-flight requests for this pushkin. "
                 "(Something is wrong and Sygnal is struggling to keep up!)"

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -162,8 +162,8 @@ class ConcurrencyLimitedPushkin(Pushkin):
         # Grab an instance of the dropped request counter given our pushkin name.
         # Note this ensures the counter appears in metrics even if it hasn't yet
         # been incremented.
-        self.dropped_requests_counter = (
-            ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(pushkin=name)
+        self.dropped_requests_counter = ConcurrencyLimitedPushkin.RATELIMITING_DROPPED_REQUESTS.labels(
+            pushkin=name
         )
 
     async def dispatch_notification(


### PR DESCRIPTION
The `sygnal_inflight_request_limit_drop` is a Counter that counts how many requests were dropped due to a pushkin hitting its concurrent request limit, and was added in https://github.com/matrix-org/sygnal/pull/146.

A quirk of counter metrics with a label is that they will not show up in prometheus until they are initially referenced. This had the side-effect of not being able to easily monitor/alert on the metric until something actually went wrong

This PR references and sets up a instance variable with the pushkin's name as a label immediately, ensuring it appears as 0 in prometheus upon startup.