### PR TITLE
Remove useless log line

### DIFF
--- a/changelog.d/174.misc
+++ b/changelog.d/174.misc
@@ -1,0 +1,1 @@
+Remove extraneous log line.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -268,8 +268,6 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
 
             for retry_number in range(self.MAX_TRIES):
                 try:
-                    log.debug("Trying")
-
                     span_tags = {"retry_num": retry_number}
 
                     with self.sygnal.tracer.start_span(


### PR DESCRIPTION
I initially tried adapting this log line to include some information relevant to the request, but all that's available here for the device was its app_id (too generic) and pushkey (probably not a good idea to log).

So instead I've opted to remove it as I feel it's not too useful on its own (it's also quite spammy). Plus you probably only care when a push notification fails to send, which is logged below.