### PR TITLE
Whitelist webpush endpoints

### DIFF
--- a/changelog.d/182.feature
+++ b/changelog.d/182.feature
@@ -1,1 +1,1 @@
-Add 'allowed_endpoints' configuration option for webpush pushkins to whitelist the allowed endpoints.
+Add 'allowed_endpoints' configuration option for limiting the endpoints that WebPush pushkins will contact.

--- a/changelog.d/182.feature
+++ b/changelog.d/182.feature
@@ -1,0 +1,1 @@
+Add 'allowed_endpoints' configuration option for webpush pushkins to whitelist the allowed endpoints.

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -226,6 +226,19 @@ You also need to set an e-mail address in `vapid_contact_email` in the config fi
 where the push gateway operator can reach you in case they need to notify you
 about your usage of their API.
 
+Since for webpush, the push gateway endpoint is variable and comes from the browser
+through the push data, you may not want to have your sygnal instance connect to any
+random addressable server. For this, you can set the `allowed_endpoints` option to
+a list of allowed endpoints. Globs are supported. For example, to allow Firefox,
+Chrome and Opera (Google) and Edge as a push gateway, you can use this:
+
+```yaml
+allowed_endpoints:
+    - "updates.push.services.mozilla.com"
+    - "fcm.googleapis.com"
+    - "*.notify.windows.com"
+```
+
 #### Push key and expected push data
 
 In your web application, [the push manager subscribe method](https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe)

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -15,7 +15,7 @@
 from logging import LoggerAdapter
 
 from twisted.internet.defer import Deferred
-
+import re
 
 async def twisted_sleep(delay, twisted_reactor):
     """
@@ -37,3 +37,27 @@ async def twisted_sleep(delay, twisted_reactor):
 class NotificationLoggerAdapter(LoggerAdapter):
     def process(self, msg, kwargs):
         return f"[{self.extra['request_id']}] {msg}", kwargs
+
+
+def glob_to_regex(glob):
+    """Converts a glob to a compiled regex object.
+
+    The regex is anchored at the beginning and end of the string.
+
+    Args:
+        glob (str)
+
+    Returns:
+        re.RegexObject
+    """
+    res = ""
+    for c in glob:
+        if c == "*":
+            res = res + ".*"
+        elif c == "?":
+            res = res + "."
+        else:
+            res = res + re.escape(c)
+
+    # \A anchors at start of string, \Z at end of string
+    return re.compile(r"\A" + res + r"\Z", re.IGNORECASE)

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -17,6 +17,7 @@ from logging import LoggerAdapter
 from twisted.internet.defer import Deferred
 import re
 
+
 async def twisted_sleep(delay, twisted_reactor):
     """
     Creates a Deferred which will fire in a set time.

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 from logging import LoggerAdapter
 
 from twisted.internet.defer import Deferred
-import re
 
 
 async def twisted_sleep(delay, twisted_reactor):

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -137,8 +137,8 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     "push gateway %s is not in allowed_endpoints, blocking request",
                     endpoint_domain,
                 )
+                # abort, but don't reject push key
                 return []
-                # don't reject push key though
 
         if not p256dh or not endpoint or not auth:
             logger.warn(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -16,8 +16,8 @@ import json
 import logging
 import os.path
 from io import BytesIO
-from urllib.parse import urlparse
 from typing import List, Optional, Pattern
+from urllib.parse import urlparse
 
 from prometheus_client import Gauge, Histogram
 from py_vapid import Vapid, VapidException

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -129,15 +129,10 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         auth = device.data.get("auth")
         endpoint_domain = urlparse(endpoint).netloc
         if self.allowed_endpoints:
-            match = next(
-                (
-                    regex
-                    for regex in self.allowed_endpoints
-                    if regex.fullmatch(endpoint_domain)
-                ),
-                None,
+            allowed = any(
+                regex.fullmatch(endpoint_domain) for regex in self.allowed_endpoints
             )
-            if not match:
+            if not allowed:
                 logger.error(
                     "push gateway %s is not in allowed_endpoints, blocking request",
                     endpoint_domain,

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -17,6 +17,7 @@ import logging
 import os.path
 from io import BytesIO
 from urllib.parse import urlparse
+from typing import List, Optional, Pattern
 
 from prometheus_client import Gauge, Histogram
 from py_vapid import Vapid, VapidException
@@ -97,6 +98,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         )
         self.http_agent_wrapper = HttpAgentWrapper(self.http_agent)
 
+        self.allowed_endpoints = None  # type: Optional[List[Pattern]]
         allowed_endpoints = self.get_config("allowed_endpoints")
         if allowed_endpoints:
             if not isinstance(allowed_endpoints, list):
@@ -104,8 +106,6 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     "'allowed_endpoints' should be a list or not set"
                 )
             self.allowed_endpoints = list(map(glob_to_regex, allowed_endpoints))
-        else:
-            self.allowed_endpoints = None
         privkey_filename = self.get_config("vapid_private_key")
         if not privkey_filename:
             raise PushkinSetupException("'vapid_private_key' not set in config")

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -100,7 +100,9 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         allowed_endpoints = self.get_config("allowed_endpoints")
         if allowed_endpoints:
             if not isinstance(allowed_endpoints, list):
-                raise PushkinSetupException("'allowed_endpoints' should be a list or not set")
+                raise PushkinSetupException(
+                    "'allowed_endpoints' should be a list or not set"
+                )
             self.allowed_endpoints = list(map(glob_to_regex, allowed_endpoints))
         privkey_filename = self.get_config("vapid_private_key")
         if not privkey_filename:
@@ -127,10 +129,21 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         auth = device.data.get("auth")
         endpoint_domain = urlparse(endpoint).netloc
         if self.allowed_endpoints:
-            match = next((regex for regex in self.allowed_endpoints if regex.fullmatch(endpoint_domain)), None)
+            match = next(
+                (
+                    regex
+                    for regex in self.allowed_endpoints
+                    if regex.fullmatch(endpoint_domain)
+                ),
+                None,
+            )
             if not match:
-                logger.error("push gateway %s is not in allowed_endpoints, blocking request", endpoint_domain)
-                return []; # don't reject push key though
+                logger.error(
+                    "push gateway %s is not in allowed_endpoints, blocking request",
+                    endpoint_domain,
+                )
+                return []
+                # don't reject push key though
 
         if not p256dh or not endpoint or not auth:
             logger.warn(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -28,9 +28,9 @@ from twisted.web.http_headers import Headers
 from sygnal.helper.context_factory import ClientTLSOptionsFactory
 from sygnal.helper.proxy.proxyagent_twisted import ProxyAgent
 
-from .utils import glob_to_regex
 from .exceptions import PushkinSetupException
 from .notifications import ConcurrencyLimitedPushkin
+from .utils import glob_to_regex
 
 QUEUE_TIME_HISTOGRAM = Histogram(
     "sygnal_webpush_queue_time",

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -104,6 +104,8 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     "'allowed_endpoints' should be a list or not set"
                 )
             self.allowed_endpoints = list(map(glob_to_regex, allowed_endpoints))
+        else:
+            self.allowed_endpoints = None
         privkey_filename = self.get_config("vapid_private_key")
         if not privkey_filename:
             raise PushkinSetupException("'vapid_private_key' not set in config")


### PR DESCRIPTION
through an optional `allowed_endpoints` configuration key

I added support for globs because some browser vendor endpoints seem to contain sharding identifiers in the subdomain.