### PR TITLE
set time-to-live for webpush messages

### DIFF
--- a/changelog.d/185.bugfix
+++ b/changelog.d/185.bugfix
@@ -1,0 +1,1 @@
+Add `ttl` option as understood config option for WebPush pushkins to make delivery more reliable

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -239,6 +239,8 @@ allowed_endpoints:
     - "*.notify.windows.com"
 ```
 
+A default time-to-live of 15 minutes is set for webpush, but you can adjust this by setting the `ttl: <number of seconds>` configuration option for the pusher. If notifications can't be delivered by the push gateway aftet this time, they are dropped.
+
 #### Push key and expected push data
 
 In your web application, [the push manager subscribe method](https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe)

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -121,12 +121,9 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         self.vapid_contact_email = self.get_config("vapid_contact_email")
         if not self.vapid_contact_email:
             raise PushkinSetupException("'vapid_contact_email' not set in config")
-        self.ttl = self.get_config("ttl")
-        if self.ttl:
-            if not isinstance(self.ttl, int):
-                raise PushkinSetupException("'ttl' must be an int if set")
-        else:
-            self.ttl = DEFAULT_TTL
+        self.ttl = self.get_config("ttl", DEFAULT_TTL)
+        if not isinstance(self.ttl, int):
+            raise PushkinSetupException("'ttl' must be an int if set")
 
     async def _dispatch_notification_unlimited(self, n, device, context):
         p256dh = device.pushkey

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -68,6 +68,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         "vapid_private_key",
         "vapid_contact_email",
         "allowed_endpoints",
+        "ttl",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     def __init__(self, name, sygnal, config):

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -193,7 +193,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     response_text = (await readBody(response)).decode()
         finally:
             self.connection_semaphore.release()
-        
+
         # assume 4xx is permanent and 5xx is temporary
         if 400 <= response.code < 500:
             logger.warn(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -203,13 +203,6 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                 response_text,
             )
             return [device.pushkey]
-        logger.info(
-            "Sent! pushkey %s; gateway %s response: %d: %s",
-            device.pushkey,
-            endpoint_domain,
-            response.code,
-            response_text,
-        )
         return []
 
     @staticmethod

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -193,6 +193,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     response_text = (await readBody(response)).decode()
         finally:
             self.connection_semaphore.release()
+        
         # assume 4xx is permanent and 5xx is temporary
         if 400 <= response.code < 500:
             logger.warn(


### PR DESCRIPTION
Configurable with a default of 15 minutes.