### PR TITLE
Fix ConnectTimeoutError when installing Sygnal and its dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,13 @@ This creates an isolated virtual Python environment ("virtualenv") just for
 use with Sygnal, then installs Sygnal along with its dependencies, and lastly
 installs a handful of useful tools
 
+If you  get a `ConnectTimeoutError` while installing Sygnal along with its dependencies, this is caused by `pip timeout`, `pip` has a default timeout of 15 sec, you can append `--timeout=sec` to `./venv/bin/pip install -e '.[dev]'`
+
+```bash
+python3 -m venv venv
+./venv/bin/pip timeout=1000 install -e '.[dev]'
+```
+
 Finally, activate the virtualenv by running:
 
 ```bash

--- a/changelog.d/211.doc
+++ b/changelog.d/211.doc
@@ -1,0 +1,1 @@
+Update CONTRIBUTING.md to specify how to run install sygnal and its dependecies when getting ConnectTimeoutError. Contributed by Omar Mohamed.

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     ],
     extras_require={
         "dev": [
-            "black==19.10b0",
+            "black==20.8b1",
             "flake8==3.8.3",
             "isort~=5.0",
             "mypy==0.780",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     extras_require={
         "dev": [
             "black==20.8b1",
-            "flake8==3.8.3",
+            "flake8==3.9.0",
             "isort~=5.0",
             "mypy==0.780",
             "mypy-zope==0.2.7",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
             "flake8==3.9.0",
             "isort~=5.0",
             "mypy==0.812",
-            "mypy-zope==0.2.7",
+            "mypy-zope==0.3.0",
             "tox",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             "black==20.8b1",
             "flake8==3.9.0",
             "isort~=5.0",
-            "mypy==0.780",
+            "mypy==0.812",
             "mypy-zope==0.2.7",
             "tox",
         ]


### PR DESCRIPTION
`ConnectTimeoutError `is thrown out when `pip` default timeout is exceeded, _(15 sec is the default pip timeout)_ this is caused by poor internet connectivity.


