### PR TITLE
WebPush reliability improvements

### DIFF
--- a/changelog.d/185.bugfix
+++ b/changelog.d/185.bugfix
@@ -1,1 +1,0 @@
-Add `ttl` option as understood config option for WebPush pushkins to make delivery more reliable

--- a/changelog.d/185.bugfix
+++ b/changelog.d/185.bugfix
@@ -1,0 +1,1 @@
+Add `ttl` option as understood config option for WebPush pushkins to make delivery more reliable

--- a/changelog.d/212.feature
+++ b/changelog.d/212.feature
@@ -1,0 +1,1 @@
+Prevent the push key from being rejected for temporary errors and oversized payloads, add TTL logging, and support events_only push data flag.

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -253,6 +253,12 @@ any properties set in it will be present in the push messages you receive,
 so it can be used to pass identifiers specific to your client
 (like which account the notification is for).
 
+##### events_only
+
+As of the time of writing, all webpush-supporting browsers require you to set `userVisibleOnly: true` when calling (`pushManager.subscribe`)[https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe], to (prevent abusing webpush to track users)[https://goo.gl/yqv4Q4] without their knowledge. With this (mandatory) flag, the browser will show a "site has been updated in the background" notification if no notifications are visible after your service worker processes a `push` event. This can easily happen when sygnal sends a push message to clear the unread count, which is not specific to an event. With `events_only: true` in the pusher data, sygnal won't forward any push message without a event id. This prevents your service worker being forced to show a notification to push messages that clear the unread count.
+
+##### Multiple pushers on one origin
+
 Also note that because you can only have one push subscription per service worker,
 and hence per origin, you might create pushers for different accounts with the same 
 p256dh push key. To prevent the server from removing other pushers with the same 

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -191,7 +191,6 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     response_text = (await readBody(response)).decode()
         finally:
             self.connection_semaphore.release()
-
         # assume 4xx is permanent and 5xx is temporary
         if 400 <= response.code < 500:
             logger.warn(
@@ -202,6 +201,13 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                 response_text,
             )
             return [device.pushkey]
+        logger.info(
+            "Sent! pushkey %s; gateway %s response: %d: %s",
+            device.pushkey,
+            endpoint_domain,
+            response.code,
+            response_text,
+        )
         return []
 
     @staticmethod

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -133,6 +133,11 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             )
             return [device.pushkey]
 
+        # drop notifications without an event id if requested,
+        # see https://github.com/matrix-org/sygnal/issues/186
+        if device.data.get("events_only") is True and not n.event_id:
+            return [];
+
         endpoint = device.data.get("endpoint")
         auth = device.data.get("auth")
         endpoint_domain = urlparse(endpoint).netloc

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -57,6 +57,7 @@ DEFAULT_MAX_CONNECTIONS = 20
 DEFAULT_TTL = 15 * 60  # in seconds
 # Max payload size is 4096
 MAX_BODY_LENGTH = 1000
+MAX_CIPHERTEXT_LENGTH = 2000
 
 
 class WebpushPushkin(ConcurrencyLimitedPushkin):
@@ -256,7 +257,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             if isinstance(body, str) and len(body) > MAX_BODY_LENGTH:
                 content["body"] = body[0 : MAX_BODY_LENGTH - 1] + "…"
             ciphertext = content.get("ciphertext")
-            if isinstance(ciphertext, str) and len(ciphertext) > MAX_BODY_LENGTH:
+            if isinstance(ciphertext, str) and len(ciphertext) > MAX_CIPHERTEXT_LENGTH:
                 content.pop("ciphertext", None)
             payload["content"] = content
 

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -55,8 +55,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_CONNECTIONS = 20
 DEFAULT_TTL = 15 * 60  # in seconds
-MAX_BODY_LENGTH = 2000
-MAX_PAYLOAD_LENGTH = 4096
+# Max payload size is 4096
+MAX_BODY_LENGTH = 1000
 
 
 class WebpushPushkin(ConcurrencyLimitedPushkin):

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -198,7 +198,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             self.connection_semaphore.release()
 
         # permanent errors
-        if response.code is 404 or response.code is 410:
+        if response.code == 404 or response.code == 410:
             logger.warn(
                 "Rejecting pushkey %s; subscription is invalid on %s: %d: %s",
                 device.pushkey,
@@ -216,7 +216,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                 response.code,
                 response_text,
             )
-        elif response.code is not 201:
+        elif response.code != 201:
             logger.info(
                 "webpush request for pushkey %s didn't respond with 201; %s responded with %d: %s",
                 device.pushkey,

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -138,7 +138,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         # drop notifications without an event id if requested,
         # see https://github.com/matrix-org/sygnal/issues/186
         if device.data.get("events_only") is True and not n.event_id:
-            return [];
+            return []
 
         endpoint = device.data.get("endpoint")
         auth = device.data.get("auth")
@@ -182,7 +182,6 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         with QUEUE_TIME_HISTOGRAM.time():
             with PENDING_REQUESTS_GAUGE.track_inprogress():
                 await self.connection_semaphore.acquire()
-
         try:
             with SEND_TIME_HISTOGRAM.time():
                 with ACTIVE_REQUESTS_GAUGE.track_inprogress():
@@ -200,7 +199,8 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             self.connection_semaphore.release()
 
         reject_pushkey = self._handle_response(
-            response, response_text, device.pushkey, endpoint_domain)
+            response, response_text, device.pushkey, endpoint_domain
+        )
         if reject_pushkey:
             return [device.pushkey]
         return []
@@ -254,7 +254,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             body = content.get("body")
             # make some attempts to not go over the max payload length
             if isinstance(body, str) and len(body) > MAX_BODY_LENGTH:
-                content["body"] = body[0: MAX_BODY_LENGTH - 1] + "…"
+                content["body"] = body[0 : MAX_BODY_LENGTH - 1] + "…"
             ciphertext = content.get("ciphertext")
             if isinstance(ciphertext, str) and len(ciphertext) > MAX_BODY_LENGTH:
                 content.pop("ciphertext", None)
@@ -282,7 +282,6 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     )
             except:
                 pass
-
         # permanent errors
         if response.code == 404 or response.code == 410:
             logger.warn(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -191,6 +191,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     response_text = (await readBody(response)).decode()
         finally:
             self.connection_semaphore.release()
+        
         # assume 4xx is permanent and 5xx is temporary
         if 400 <= response.code < 500:
             logger.warn(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -304,7 +304,8 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             )
         elif response.code != 201:
             logger.info(
-                "webpush request for pushkey %s didn't respond with 201; %s responded with %d: %s",
+                "webpush request for pushkey %s didn't respond with 201; "
+                + "%s responded with %d: %s",
                 pushkey,
                 endpoint_domain,
                 response.code,

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -281,7 +281,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                         endpoint_domain,
                         ttl_given,
                     )
-            except:
+            except ValueError:
                 pass
         # permanent errors
         if response.code == 404 or response.code == 410:

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -191,7 +191,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                     response_text = (await readBody(response)).decode()
         finally:
             self.connection_semaphore.release()
-        
+
         # assume 4xx is permanent and 5xx is temporary
         if 400 <= response.code < 500:
             logger.warn(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -201,13 +201,6 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                 response_text,
             )
             return [device.pushkey]
-        logger.info(
-            "Sent! pushkey %s; gateway %s response: %d: %s",
-            device.pushkey,
-            endpoint_domain,
-            response.code,
-            response_text,
-        )
         return []
 
     @staticmethod


### PR DESCRIPTION
Part of https://github.com/matrix-org/sygnal/issues/186:
 - Only reject push key on 404 or 410 response codes
 - Trim message body so we don't exceed 4096 characters
 - Log when returned TTL header is lower than request
 - Support events_only flag on push data, to avoid bogus notifications in browser.