### PR TITLE
WebPush support for urgency and coalescing

### DIFF
--- a/changelog.d/213.feature
+++ b/changelog.d/213.feature
@@ -1,0 +1,1 @@
+WebPush: add support for Urgency and Topic header

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -270,7 +270,7 @@ forced to show a notification to push messages that clear the unread count.
 ##### only_last_per_room
 
 You can opt in to only receive the last notification per room by setting
-`only_last_per_room: true` in the push data. Note that if a first notification
+`only_last_per_room: true` in the push data. Note that if the first notification
 can be delivered before the second one is sent, you will still get both;
 it only has an effect when notifications are queued up on the gateway.
 

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -257,6 +257,10 @@ so it can be used to pass identifiers specific to your client
 
 As of the time of writing, all webpush-supporting browsers require you to set `userVisibleOnly: true` when calling (`pushManager.subscribe`)[https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe], to (prevent abusing webpush to track users)[https://goo.gl/yqv4Q4] without their knowledge. With this (mandatory) flag, the browser will show a "site has been updated in the background" notification if no notifications are visible after your service worker processes a `push` event. This can easily happen when sygnal sends a push message to clear the unread count, which is not specific to an event. With `events_only: true` in the pusher data, sygnal won't forward any push message without a event id. This prevents your service worker being forced to show a notification to push messages that clear the unread count.
 
+##### only_last_per_room
+
+You can opt in to only receive the last notification per room by setting `only_last_per_room: true` in the push data. Note that if a first notification can be delivered before the second one is sent, you will still get both; it only has effect for when notifications are queued up on the gateway.
+
 ##### Multiple pushers on one origin
 
 Also note that because you can only have one push subscription per service worker,

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -272,7 +272,7 @@ forced to show a notification to push messages that clear the unread count.
 You can opt in to only receive the last notification per room by setting
 `only_last_per_room: true` in the push data. Note that if a first notification
 can be delivered before the second one is sent, you will still get both;
-it only has effect for when notifications are queued up on the gateway.
+it only has an effect when notifications are queued up on the gateway.
 
 ##### Multiple pushers on one origin
 

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -255,11 +255,24 @@ so it can be used to pass identifiers specific to your client
 
 ##### events_only
 
-As of the time of writing, all webpush-supporting browsers require you to set `userVisibleOnly: true` when calling (`pushManager.subscribe`)[https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe], to (prevent abusing webpush to track users)[https://goo.gl/yqv4Q4] without their knowledge. With this (mandatory) flag, the browser will show a "site has been updated in the background" notification if no notifications are visible after your service worker processes a `push` event. This can easily happen when sygnal sends a push message to clear the unread count, which is not specific to an event. With `events_only: true` in the pusher data, sygnal won't forward any push message without a event id. This prevents your service worker being forced to show a notification to push messages that clear the unread count.
+As of the time of writing, all webpush-supporting browsers require you to set 
+`userVisibleOnly: true` when calling (`pushManager.subscribe`)
+[https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe], to 
+(prevent abusing webpush to track users)[https://goo.gl/yqv4Q4] without their 
+knowledge. With this (mandatory) flag, the browser will show a "site has been 
+updated in the background" notification if no notifications are visible after
+your service worker processes a `push` event. This can easily happen when sygnal
+sends a push message to clear the unread count, which is not specific
+to an event. With `events_only: true` in the pusher data, sygnal won't forward
+any push message without a event id. This prevents your service worker being
+forced to show a notification to push messages that clear the unread count.
 
 ##### only_last_per_room
 
-You can opt in to only receive the last notification per room by setting `only_last_per_room: true` in the push data. Note that if a first notification can be delivered before the second one is sent, you will still get both; it only has effect for when notifications are queued up on the gateway.
+You can opt in to only receive the last notification per room by setting
+`only_last_per_room: true` in the push data. Note that if a first notification
+can be delivered before the second one is sent, you will still get both;
+it only has effect for when notifications are queued up on the gateway.
 
 ##### Multiple pushers on one origin
 

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -361,8 +361,8 @@ class HttpDelayedRequest:
     pywebpush expects a synchronous API, while we use an asynchronous API.
 
     To keep pywebpush happy we present it with some hardcoded values that
-    make its assertions pass while the async network call is happening
-    in the background.
+    make its assertions pass even though the HTTP request has not yet been
+    made.
 
     Attributes:
         status_code (int):

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -183,9 +183,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             # ask for a 22 byte hash, so the base64 of it is 32,
             # the limit webpush allows for the topic
             topic = urlsafe_b64encode(
-                blake2s(
-                    n.room_id.encode(), digest_size=22, usedforsecurity=False
-                ).digest()
+                blake2s(n.room_id.encode(), digest_size=22).digest()
             )
 
         # note that webpush modifies vapid_claims, so make sure it's only used once

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -357,7 +357,7 @@ class HttpDelayedRequest:
     The request isn't immediately executed, to allow adding headers
     not supported by pywebpush, like Topic and Urgency.
 
-    Provide a response object that matches the API expected from pywebpush.
+    Also provides the interface that pywebpush expects from a response object.
     pywebpush expects a synchronous API, while we use an asynchronous API.
 
     To keep pywebpush happy we present it with some hardcoded values that

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -179,7 +179,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         low_priority = n.prio == "low"
         # allow dropping earlier notifications in the same room if requested
         topic = None
-        if n.room_id and device.data.get("only_last_per_room") == True:
+        if n.room_id and device.data.get("only_last_per_room") is True:
             # ask for a 22 byte hash, so the base64 of it is 32,
             # the limit webpush allows for the topic
             topic = urlsafe_b64encode(

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -393,11 +393,10 @@ class HttpDelayedRequest:
             b"Urgency": ["low" if low_priority else "normal"],
         }
         if topic:
-            headers[b"Topic"] = topic
-
+            headers[b"Topic"] = [ topic ]
         return http_agent.request(
             b"POST",
-            endpoint.encode(),
+            self.endpoint.encode(),
             headers=Headers(headers),
             bodyProducer=body_producer,
         )

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -393,7 +393,7 @@ class HttpDelayedRequest:
             b"Urgency": ["low" if low_priority else "normal"],
         }
         if topic:
-            headers[b"Topic"] = [ topic ]
+            headers[b"Topic"] = [topic]
         return http_agent.request(
             b"POST",
             self.endpoint.encode(),


### PR DESCRIPTION
Related to https://github.com/matrix-org/sygnal/issues/186, based off #212 :
 - support dropping earlier notifications in the same room using the [`Topic` header](https://tools.ietf.org/html/draft-ietf-webpush-protocol-12#section-5.4)
 - set the `Urgency` header based on the notification prio field.