### PR TITLE
Be stricter about JSON that is accepted by Sygnal

### DIFF
--- a/changelog.d/216.bugfix
+++ b/changelog.d/216.bugfix
@@ -1,0 +1,1 @@
+Fix a long-standing bug where invalid JSON would be accepted over the HTTP interfaces.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -32,7 +32,7 @@ from sygnal.exceptions import (
 )
 from sygnal.helper.context_factory import ClientTLSOptionsFactory
 from sygnal.helper.proxy.proxyagent_twisted import ProxyAgent
-from sygnal.utils import NotificationLoggerAdapter, json_decoder, twisted_sleep
+from sygnal.utils import NotificationLoggerAdapter, safe_json_loads, twisted_sleep
 
 from .exceptions import PushkinSetupException
 from .notifications import ConcurrencyLimitedPushkin
@@ -250,7 +250,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             return pushkeys, []
         elif 200 <= response.code < 300:
             try:
-                resp_object = json_decoder.decode(response_text)
+                resp_object = safe_json_loads(response_text)
             except ValueError:
                 raise NotificationDispatchException("Invalid JSON response from GCM.")
             if "results" not in resp_object:

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -32,7 +32,7 @@ from sygnal.exceptions import (
 )
 from sygnal.helper.context_factory import ClientTLSOptionsFactory
 from sygnal.helper.proxy.proxyagent_twisted import ProxyAgent
-from sygnal.utils import NotificationLoggerAdapter, safe_json_loads, twisted_sleep
+from sygnal.utils import NotificationLoggerAdapter, json_decoder, twisted_sleep
 
 from .exceptions import PushkinSetupException
 from .notifications import ConcurrencyLimitedPushkin
@@ -250,7 +250,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             return pushkeys, []
         elif 200 <= response.code < 300:
             try:
-                resp_object = safe_json_loads(response_text)
+                resp_object = json_decoder.decode(response_text)
             except ValueError:
                 raise NotificationDispatchException("Invalid JSON response from GCM.")
             if "results" not in resp_object:

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -18,7 +18,6 @@ import json
 import logging
 import time
 from io import BytesIO
-from json import JSONDecodeError
 
 from opentracing import logs, tags
 from prometheus_client import Counter, Gauge, Histogram

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -33,7 +33,7 @@ from sygnal.exceptions import (
 )
 from sygnal.helper.context_factory import ClientTLSOptionsFactory
 from sygnal.helper.proxy.proxyagent_twisted import ProxyAgent
-from sygnal.utils import NotificationLoggerAdapter, twisted_sleep
+from sygnal.utils import NotificationLoggerAdapter, twisted_sleep, json_decoder
 
 from .exceptions import PushkinSetupException
 from .notifications import ConcurrencyLimitedPushkin
@@ -251,8 +251,8 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             return pushkeys, []
         elif 200 <= response.code < 300:
             try:
-                resp_object = json.loads(response_text)
-            except JSONDecodeError:
+                resp_object = json_decoder.decode(response_text)
+            except ValueError:
                 raise NotificationDispatchException("Invalid JSON response from GCM.")
             if "results" not in resp_object:
                 log.error(

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -32,7 +32,7 @@ from sygnal.exceptions import (
 )
 from sygnal.helper.context_factory import ClientTLSOptionsFactory
 from sygnal.helper.proxy.proxyagent_twisted import ProxyAgent
-from sygnal.utils import NotificationLoggerAdapter, twisted_sleep, json_decoder
+from sygnal.utils import NotificationLoggerAdapter, json_decoder, twisted_sleep
 
 from .exceptions import PushkinSetupException
 from .notifications import ConcurrencyLimitedPushkin

--- a/sygnal/http.py
+++ b/sygnal/http.py
@@ -35,7 +35,7 @@ from twisted.web.resource import Resource
 from twisted.web.server import NOT_DONE_YET
 
 from sygnal.notifications import NotificationContext
-from sygnal.utils import NotificationLoggerAdapter, json_decoder
+from sygnal.utils import NotificationLoggerAdapter, safe_json_loads
 
 from .exceptions import InvalidNotificationException, NotificationDispatchException
 from .notifications import Notification
@@ -133,7 +133,7 @@ class V1NotifyHandler(Resource):
             log = NotificationLoggerAdapter(logger, {"request_id": request_id})
 
             try:
-                body = json_decoder.decode(request.content.read())
+                body = safe_json_loads(request.content.read())
             except Exception as exc:
                 msg = "Expected JSON request body"
                 log.warning(msg, exc_info=exc)

--- a/sygnal/http.py
+++ b/sygnal/http.py
@@ -35,7 +35,7 @@ from twisted.web.resource import Resource
 from twisted.web.server import NOT_DONE_YET
 
 from sygnal.notifications import NotificationContext
-from sygnal.utils import NotificationLoggerAdapter
+from sygnal.utils import NotificationLoggerAdapter, json_decoder
 
 from .exceptions import InvalidNotificationException, NotificationDispatchException
 from .notifications import Notification
@@ -133,7 +133,7 @@ class V1NotifyHandler(Resource):
             log = NotificationLoggerAdapter(logger, {"request_id": request_id})
 
             try:
-                body = json.loads(request.content.read())
+                body = json_decoder.decode(request.content.read())
             except Exception as exc:
                 msg = "Expected JSON request body"
                 log.warning(msg, exc_info=exc)

--- a/sygnal/http.py
+++ b/sygnal/http.py
@@ -35,7 +35,7 @@ from twisted.web.resource import Resource
 from twisted.web.server import NOT_DONE_YET
 
 from sygnal.notifications import NotificationContext
-from sygnal.utils import NotificationLoggerAdapter, safe_json_loads
+from sygnal.utils import NotificationLoggerAdapter, json_decoder
 
 from .exceptions import InvalidNotificationException, NotificationDispatchException
 from .notifications import Notification
@@ -133,7 +133,7 @@ class V1NotifyHandler(Resource):
             log = NotificationLoggerAdapter(logger, {"request_id": request_id})
 
             try:
-                body = safe_json_loads(request.content.read())
+                body = json_decoder.decode(request.content.read().decode("utf-8"))
             except Exception as exc:
                 msg = "Expected JSON request body"
                 log.warning(msg, exc_info=exc)

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import json
 import re
+from functools import partial
 from logging import LoggerAdapter
 
 from twisted.internet.defer import Deferred
@@ -67,8 +68,8 @@ def glob_to_regex(glob):
 
 def _reject_invalid_json(val):
     """Do not allow Infinity, -Infinity, or NaN values in JSON."""
-    raise ValueError("Invalid JSON value: '%s'" % val)
+    raise ValueError(f"Invalid JSON value: {val!r}")
 
 
 # a custom JSON decoder which will reject Python extensions to JSON.
-json_decoder = json.JSONDecoder(parse_constant=_reject_invalid_json)
+safe_json_loads = partial(json.loads, parse_constant=_reject_invalid_json)

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import re
 from logging import LoggerAdapter
 
@@ -62,3 +63,12 @@ def glob_to_regex(glob):
 
     # \A anchors at start of string, \Z at end of string
     return re.compile(r"\A" + res + r"\Z", re.IGNORECASE)
+
+
+def _reject_invalid_json(val):
+    """Do not allow Infinity, -Infinity, or NaN values in JSON."""
+    raise ValueError("Invalid JSON value: '%s'" % val)
+
+
+# a custom JSON decoder which will reject Python extensions to JSON.
+json_decoder = json.JSONDecoder(parse_constant=_reject_invalid_json)

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import json
 import re
-from functools import partial
 from logging import LoggerAdapter
 
 from twisted.internet.defer import Deferred
@@ -72,4 +71,4 @@ def _reject_invalid_json(val):
 
 
 # a custom JSON decoder which will reject Python extensions to JSON.
-safe_json_loads = partial(json.loads, parse_constant=_reject_invalid_json)
+json_decoder = json.JSONDecoder(parse_constant=_reject_invalid_json)


### PR DESCRIPTION
This disables the JSON extensions which Python supports by default (parsing of
`Infinity` / `-Infinity` and `NaN`). These shouldn't be accepted since they're
not technically valid JSON and other languages won't be able to interpret it
properly.