### PR TITLE
Improve static type checking

### DIFF
--- a/changelog.d/223.misc
+++ b/changelog.d/223.misc
@@ -1,0 +1,1 @@
+Improve static type checking. Contributed by Omar Mohamed.

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -15,10 +15,10 @@
 # Copied and adapted from
 # https://raw.githubusercontent.com/matrix-org/pushbaby/master/pushbaby/truncate.py
 import json
-from typing import List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 
-def json_encode(payload):
+def json_encode(payload: Dict[str, Any]) -> bytes:
     return json.dumps(payload, ensure_ascii=False).encode()
 
 

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -15,10 +15,10 @@
 # Copied and adapted from
 # https://raw.githubusercontent.com/matrix-org/pushbaby/master/pushbaby/truncate.py
 import json
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 
-def json_encode(payload: Dict[str, Any]) -> bytes:
+def json_encode(payload: Any) -> bytes:
     return json.dumps(payload, ensure_ascii=False).encode()
 
 


### PR DESCRIPTION
Add type annotation to `json_encode Function` on `apnstruncate.py` file

