### PR TITLE
Improve static type checking

### DIFF
--- a/changelog.d/225.misc
+++ b/changelog.d/225.misc
@@ -1,0 +1,1 @@
+Improve static type checking. Contributed by Omar Mohamed.

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -26,7 +26,7 @@ class BodyTooLongException(Exception):
     pass
 
 
-def is_too_long(payload: Dict[Any, Any], max_length: int = 2048) -> bool:
+def is_too_long(payload: dict, max_length: int = 2048) -> bool:
     """
     Returns True if the given payload dictionary is too long for a push.
     Note that the maximum is now 2kB "In iOS 8 and later" although in

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -15,7 +15,7 @@
 # Copied and adapted from
 # https://raw.githubusercontent.com/matrix-org/pushbaby/master/pushbaby/truncate.py
 import json
-from typing import Any, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 
 def json_encode(payload: Any) -> bytes:
@@ -26,7 +26,7 @@ class BodyTooLongException(Exception):
     pass
 
 
-def is_too_long(payload, max_length=2048):
+def is_too_long(payload: Dict[Any, Any], max_length: int = 2048) -> bool:
     """
     Returns True if the given payload dictionary is too long for a push.
     Note that the maximum is now 2kB "In iOS 8 and later" although in

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -15,7 +15,7 @@
 # Copied and adapted from
 # https://raw.githubusercontent.com/matrix-org/pushbaby/master/pushbaby/truncate.py
 import json
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 
 def json_encode(payload: Any) -> bytes:


### PR DESCRIPTION
Add type annotation to is_too_long Function on apnstruncate.py file
as part of the #201 issue
