### PR TITLE
Update towncrier CI check to run against main

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           python-version: "3.7"
       - run: python -m pip install towncrier
-      - run: python -m towncrier.check
+      - run: python -m towncrier.check --compare-with="origin/main"


### PR DESCRIPTION
Since we changed the default branch name, we need to tell Twisted what the new branch name is.