### PR TITLE
Improve `glob_to_regex` performance and add case sensitivity flag

### DIFF
--- a/changelog.d/268.misc
+++ b/changelog.d/268.misc
@@ -1,0 +1,1 @@
+Improve `glob_to_regex` performance and add case sensitivity flag.

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -41,28 +41,22 @@ class NotificationLoggerAdapter(LoggerAdapter):
         return f"[{self.extra['request_id']}] {msg}", kwargs
 
 
-def glob_to_regex(glob):
+def glob_to_regex(glob: str, ignore_case: bool) -> re.Pattern:
     """Converts a glob to a compiled regex object.
 
     The regex is anchored at the beginning and end of the string.
 
     Args:
-        glob (str)
+        glob
 
     Returns:
-        re.RegexObject
+        re.Pattern
     """
-    res = ""
-    for c in glob:
-        if c == "*":
-            res = res + ".*"
-        elif c == "?":
-            res = res + "."
-        else:
-            res = res + re.escape(c)
-
-    # \A anchors at start of string, \Z at end of string
-    return re.compile(r"\A" + res + r"\Z", re.IGNORECASE)
+    regex = re.escape(glob)
+    # `*` and `?` wildcards have been escaped. Now turn them back into regex.
+    regex = regex.replace("\\*", ".*")
+    regex = regex.replace("\\?", ".")
+    return re.compile(rf"\A{regex}\Z", re.IGNORECASE if ignore_case else 0)
 
 
 def _reject_invalid_json(val):

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -45,12 +45,6 @@ def glob_to_regex(glob: str, ignore_case: bool) -> re.Pattern:
     """Converts a glob to a compiled regex object.
 
     The regex is anchored at the beginning and end of the string.
-
-    Args:
-        glob
-
-    Returns:
-        re.Pattern
     """
     regex = re.escape(glob)
     # `*` and `?` wildcards have been escaped. Now turn them back into regex.

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -113,7 +113,10 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                 raise PushkinSetupException(
                     "'allowed_endpoints' should be a list or not set"
                 )
-            self.allowed_endpoints = list(map(glob_to_regex, allowed_endpoints))
+            self.allowed_endpoints = [
+                glob_to_regex(endpoint, ignore_case=True)
+                for endpoint in allowed_endpoints
+            ]
         privkey_filename = self.get_config("vapid_private_key")
         if not privkey_filename:
             raise PushkinSetupException("'vapid_private_key' not set in config")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+from twisted.trial import unittest
+
+from sygnal.utils import glob_to_regex
+
+
+class GlobToRegexTestCase(unittest.TestCase):
+    def test_literal(self):
+        """Tests `glob_to_regex` with only literal characters"""
+        pattern = glob_to_regex("org.matrix", ignore_case=False)
+        self.assertEqual(pattern.pattern, r"\Aorg\.matrix\Z")
+
+    def test_wildcards(self):
+        """Tests `glob_to_regex` with wildcards"""
+        pattern = glob_to_regex("org.matrix.*", ignore_case=False)
+        self.assertEqual(pattern.pattern, r"\Aorg\.matrix\..*\Z")
+
+        pattern = glob_to_regex("org.matrix.???", ignore_case=False)
+        self.assertEqual(pattern.pattern, r"\Aorg\.matrix\....\Z")
+
+    def test_ignore_case(self):
+        """Tests `glob_to_regex` case sensitivity"""
+        pattern = glob_to_regex("org.matrix", ignore_case=False)
+        self.assertEqual(pattern.flags & re.IGNORECASE, 0)
+
+        pattern = glob_to_regex("org.matrix", ignore_case=True)
+        self.assertEqual(pattern.flags & re.IGNORECASE, re.IGNORECASE)


### PR DESCRIPTION
Fixing #255 will involve more frequent usage of `glob_to_regex`, so it'd be nice if it didn't do so many string concatenations.