### PR TITLE
Fix `GcmPushkin` to handle app ID globs correctly, introduced in 0.5.0

### DIFF
--- a/changelog.d/270.bugfix
+++ b/changelog.d/270.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in 0.5.0 where GCM pushes would always fail when configured to handle an app ID glob.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -33,12 +33,7 @@ from sygnal.exceptions import (
 from sygnal.helper.context_factory import ClientTLSOptionsFactory
 from sygnal.helper.proxy.proxyagent_twisted import ProxyAgent
 from sygnal.notifications import ConcurrencyLimitedPushkin
-from sygnal.utils import (
-    NotificationLoggerAdapter,
-    glob_to_regex,
-    json_decoder,
-    twisted_sleep,
-)
+from sygnal.utils import NotificationLoggerAdapter, json_decoder, twisted_sleep
 
 QUEUE_TIME_HISTOGRAM = Histogram(
     "sygnal_gcm_queue_time", "Time taken waiting for a connection to GCM"
@@ -308,11 +303,8 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         # `Notification` with a matching app ID. We do something a little dirty and
         # perform all of our dispatches the first time we get called for a
         # `Notification` and do nothing for the rest of the times we get called.
-        app_id_pattern = glob_to_regex(self.name, ignore_case=False)
         pushkeys = [
-            device.pushkey
-            for device in n.devices
-            if app_id_pattern.match(device.app_id)
+            device.pushkey for device in n.devices if self.handles_appid(device.app_id)
         ]
         # `pushkeys` ought to never be empty here. At the very least it should contain
         # `device`'s pushkey.

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -17,6 +17,7 @@
 import abc
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, overload
 
+from matrix_common.regex import glob_to_regex
 from opentracing import Span
 from prometheus_client import Counter
 
@@ -25,7 +26,6 @@ from sygnal.exceptions import (
     NotificationDispatchException,
     PushkinSetupException,
 )
-from sygnal.utils import glob_to_regex
 
 if TYPE_CHECKING:
     from sygnal.sygnal import Sygnal

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -23,6 +23,7 @@ from sygnal.exceptions import (
     InvalidNotificationException,
     NotificationDispatchException,
 )
+from sygnal.utils import glob_to_regex
 
 if typing.TYPE_CHECKING:
     from sygnal.sygnal import Sygnal
@@ -100,6 +101,7 @@ class Notification:
 class Pushkin:
     def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]):
         self.name = name
+        self.appid_pattern = glob_to_regex(name, ignore_case=False)
         self.cfg = config
         self.sygnal = sygnal
 
@@ -107,6 +109,10 @@ class Pushkin:
         if key not in self.cfg:
             return default
         return self.cfg[key]
+
+    def handles_appid(self, appid: str) -> bool:
+        """Checks whether the pushkin is responsible for the given app ID"""
+        return self.name == appid or self.appid_pattern.match(appid) is not None
 
     async def dispatch_notification(
         self, n: Notification, device: Device, context: "NotificationContext"


### PR DESCRIPTION
Addresses #255 together with ~~#268~~ #281 and #269.