### PR TITLE
Add type hints to `sygnal/utils.py`

### DIFF
--- a/changelog.d/276.misc
+++ b/changelog.d/276.misc
@@ -1,0 +1,1 @@
+Add type hints to sygnal/utils.py.

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -34,6 +34,7 @@ from twisted.internet.interfaces import (
     IReactorFDSet,
     IReactorPluggableNameResolver,
     IReactorTCP,
+    IReactorTime,
 )
 from twisted.python import log as twisted_log
 from twisted.python.failure import Failure
@@ -67,6 +68,7 @@ class SygnalReactor(
     IReactorPluggableNameResolver,
     IReactorTCP,
     IReactorCore,
+    IReactorTime,
     Interface,
 ):
     pass

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -15,11 +15,15 @@
 import json
 import re
 from logging import LoggerAdapter
+from typing import Any, MutableMapping, Pattern, Tuple, Union
 
+from twisted.internet import asyncioreactor
 from twisted.internet.defer import Deferred
 
 
-async def twisted_sleep(delay, twisted_reactor):
+async def twisted_sleep(
+    delay: float, twisted_reactor: asyncioreactor.AsyncioSelectorReactor
+) -> None:
     """
     Creates a Deferred which will fire in a set time.
     This allows you to `await` on it and have an async analogue to
@@ -37,17 +41,19 @@ async def twisted_sleep(delay, twisted_reactor):
 
 
 class NotificationLoggerAdapter(LoggerAdapter):
-    def process(self, msg, kwargs):
+    def process(
+        self, msg: str, kwargs: MutableMapping[str, Any]
+    ) -> Tuple[str, MutableMapping[str, Any]]:
         return f"[{self.extra['request_id']}] {msg}", kwargs
 
 
-def glob_to_regex(glob):
+def glob_to_regex(glob: str) -> Union[Pattern, Pattern[str]]:
     """Converts a glob to a compiled regex object.
 
     The regex is anchored at the beginning and end of the string.
 
     Args:
-        glob (str)
+        glob
 
     Returns:
         re.RegexObject
@@ -65,7 +71,7 @@ def glob_to_regex(glob):
     return re.compile(r"\A" + res + r"\Z", re.IGNORECASE)
 
 
-def _reject_invalid_json(val):
+def _reject_invalid_json(val: Any) -> None:
     """Do not allow Infinity, -Infinity, or NaN values in JSON."""
     raise ValueError(f"Invalid JSON value: {val!r}")
 

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -17,13 +17,12 @@ import re
 from logging import LoggerAdapter
 from typing import Any, MutableMapping, Pattern, Tuple, Union
 
-from twisted.internet import asyncioreactor
 from twisted.internet.defer import Deferred
 
+from sygnal.sygnal import SygnalReactor
 
-async def twisted_sleep(
-    delay: float, twisted_reactor: asyncioreactor.AsyncioSelectorReactor
-) -> None:
+
+async def twisted_sleep(delay: float, twisted_reactor: SygnalReactor) -> None:
     """
     Creates a Deferred which will fire in a set time.
     This allows you to `await` on it and have an async analogue to

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -15,14 +15,15 @@
 import json
 import re
 from logging import LoggerAdapter
-from typing import Any, MutableMapping, Pattern, Tuple, Union
+from typing import TYPE_CHECKING, Any, MutableMapping, Pattern, Tuple, Union
 
 from twisted.internet.defer import Deferred
 
-from sygnal.sygnal import SygnalReactor
+if TYPE_CHECKING:
+    from sygnal.sygnal import SygnalReactor
 
 
-async def twisted_sleep(delay: float, twisted_reactor: SygnalReactor) -> None:
+async def twisted_sleep(delay: float, twisted_reactor: "SygnalReactor") -> None:
     """
     Creates a Deferred which will fire in a set time.
     This allows you to `await` on it and have an async analogue to

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -47,7 +47,7 @@ class NotificationLoggerAdapter(LoggerAdapter):
         return f"[{self.extra['request_id']}] {msg}", kwargs
 
 
-def glob_to_regex(glob: str) -> Union[Pattern, Pattern[str]]:
+def glob_to_regex(glob: str) -> Pattern:
     """Converts a glob to a compiled regex object.
 
     The regex is anchored at the beginning and end of the string.

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -15,7 +15,7 @@
 import json
 import re
 from logging import LoggerAdapter
-from typing import TYPE_CHECKING, Any, MutableMapping, Pattern, Tuple, Union
+from typing import TYPE_CHECKING, Any, MutableMapping, Pattern, Tuple
 
 from twisted.internet.defer import Deferred
 


### PR DESCRIPTION
As the title states.