### PR TITLE
Document the use of an iOS Notification Service Extension and the Push Gateway API as a workaround to trigger VoIP notifications on iOS.

### DIFF
--- a/changelog.d/285.doc
+++ b/changelog.d/285.doc
@@ -1,0 +1,1 @@
+Document the use of an iOS Notification Service Extension and the Push Gateway API as a workaround to trigger VoIP notifications on iOS.

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -175,6 +175,29 @@ An example `data` dictionary to specify on `POST /_matrix/client/r0/pushers/set`
 [APNs documentation]: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html
 
 
+#### VoIP (voice calls and video calls) notifications on iOS
+
+iOS is capable of displaying an on-screen call notification (with answer/deny buttons)
+and playing a ringtone.
+
+However, this requires sending a special kind of push notification.
+Sygnal is not able to send this type of push notification because a VoIP call may
+begin as a result of an encrypted message, so Sygnal has no way to know that a given
+message should initiate a VoIP call.
+
+The current workaround is for your iOS application to register a Notification
+Service Extension and to use that Notification Service Extension to trigger a
+VoIP push notification with Sygnal when your application needs to display a call
+notification.
+This is done by calling [`/_matrix/push/v1/notify`](https://spec.matrix.org/latest/push-gateway-api/#post_matrixpushv1notify).
+(There is no interface to do this locally.)
+
+The Notification Service Extension of *Element*, [available here][ElementNSE] may be
+useful for reference.
+
+[ElementNSE]: https://github.com/vector-im/element-ios/blob/034e253fb19092ef16b5262293d5c32db96aec22/RiotNSE/NotificationService.swift
+
+
 ### Firebase Cloud Messaging
 
 The client will receive a message with an FCM `data` payload with this structure:

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -192,7 +192,7 @@ As of iOS 14.5, your iOS application can register a Notification Service Extensi
 upon receiving a relevant VoIP notification, calls [`reportNewIncomingVoIPPushPayload`][iOSReportVoIP]
 to trigger a VoIP notification display on the device.
 
-[iOSReportVoIP]
+[iOSReportVoIP]: https://developer.apple.com/documentation/callkit/cxprovider/3727263-reportnewincomingvoippushpayload
 
 
 ##### Old iOS (< 14.5) versions

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -185,11 +185,23 @@ Sygnal is not able to send this type of push notification because a VoIP call ma
 begin as a result of an encrypted message, so Sygnal has no way to know that a given
 message should initiate a VoIP call.
 
-The current workaround is for your iOS application to register a Notification Service Extension
+
+##### Recent iOS (≥ 14.5) versions
+
+As of iOS 14.5, your iOS application can register a Notification Service Extension that,
+upon receiving a relevant VoIP notification, calls [`reportNewIncomingVoIPPushPayload`][iOSReportVoIP]
+to trigger a VoIP notification display on the device.
+
+[iOSReportVoIP]
+
+
+##### Old iOS (< 14.5) versions
+
+For old iOS versions, a workaround is for your iOS application to register a Notification Service Extension
 that, upon receiving a relevant VoIP notification, makes an HTTP request to Sygnal's
 [`/_matrix/push/v1/notify`](https://spec.matrix.org/latest/push-gateway-api/#post_matrixpushv1notify)
 endpoint in order to trigger the correct type of notification.
-(There is no interface to do this on-device.)
+(There was no interface to do this on-device.)
 
 The Notification Service Extension of *Element iOS*, [available here][ElementNSE],
 may be useful for reference.

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -185,15 +185,14 @@ Sygnal is not able to send this type of push notification because a VoIP call ma
 begin as a result of an encrypted message, so Sygnal has no way to know that a given
 message should initiate a VoIP call.
 
-The current workaround is for your iOS application to register a Notification
-Service Extension and to use that Notification Service Extension to trigger a
-VoIP push notification with Sygnal when your application needs to display a call
-notification.
-This is done by calling [`/_matrix/push/v1/notify`](https://spec.matrix.org/latest/push-gateway-api/#post_matrixpushv1notify).
-(There is no interface to do this locally.)
+The current workaround is for your iOS application to register a Notification Service Extension
+that, upon receiving a relevant VoIP notification, makes an HTTP request to Sygnal's
+[`/_matrix/push/v1/notify`](https://spec.matrix.org/latest/push-gateway-api/#post_matrixpushv1notify)
+endpoint in order to trigger the correct type of notification.
+(There is no interface to do this on-device.)
 
-The Notification Service Extension of *Element*, [available here][ElementNSE] may be
-useful for reference.
+The Notification Service Extension of *Element iOS*, [available here][ElementNSE],
+may be useful for reference.
 
 [ElementNSE]: https://github.com/vector-im/element-ios/blob/034e253fb19092ef16b5262293d5c32db96aec22/RiotNSE/NotificationService.swift
 


### PR DESCRIPTION
This came up as a recent community question, perfectly reasonably.

It's unfortunate that the workaround is required but as long as it is, it would be kind to document it.

