### PR TITLE
Add troubleshooting documentation for when you receive 'Could not deserialize key data' when using APNs with key files.

### DIFF
--- a/changelog.d/286.doc
+++ b/changelog.d/286.doc
@@ -1,0 +1,1 @@
+Add troubleshooting documentation for when you receive 'Could not deserialize key data' when using APNs with key files.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,6 +157,13 @@ com.example.myapp.ios:
 in your Sygnal config file.
 
 
+### 'ValueError: Could not deserialize key data'
+
+This error suggests that your key file (`.p8` file) is not valid.
+If viewed with a text editor, the file should begin with `----- BEGIN PRIVATE KEY -----`.
+If yours doesn't, you probably have the wrong kind of file.
+
+
 # Appendices
 
 ## Sending a notification to Sygnal manually with `curl`


### PR DESCRIPTION
Came up during a bit of community troubleshooting.

