### PR TITLE
Add `opentracing-types` to dev dependencies 

### DIFF
--- a/changelog.d/287.misc
+++ b/changelog.d/287.misc
@@ -1,0 +1,1 @@
+Add `opentracing-types` to the dev dependencies.

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,9 +11,6 @@ ignore_missing_imports = True
 [mypy-OpenSSL]
 ignore_missing_imports = True
 
-[mypy-opentracing.*]
-ignore_missing_imports = True
-
 [mypy-twisted.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ EXTRAS_REQUIRE = {
         "mypy-zope==0.3.0",
         "tox",
         "towncrier",
+        "types-opentracing"
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ EXTRAS_REQUIRE = {
         "mypy-zope==0.3.0",
         "tox",
         "towncrier",
-        "types-opentracing"
+        "types-opentracing",
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ EXTRAS_REQUIRE = {
         "mypy-zope==0.3.0",
         "tox",
         "towncrier",
-        "types-opentracing",
+        "types-opentracing>=2.4.2",
     ]
 }
 

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -153,7 +153,7 @@ class Sygnal:
                         scope_manager=AsyncioScopeManager(),
                     )
 
-                    self.tracer = jaeger_cfg.initialize_tracer()
+                    self.tracer = cast(Tracer, jaeger_cfg.initialize_tracer())
 
                     logger.info("Enabled OpenTracing support with Jaeger")
                 except ModuleNotFoundError:

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -153,7 +153,9 @@ class Sygnal:
                         scope_manager=AsyncioScopeManager(),
                     )
 
-                    self.tracer = cast(Tracer, jaeger_cfg.initialize_tracer())
+                    jaeger_tracer = jaeger_cfg.initialize_tracer()
+                    assert jaeger_tracer is not None
+                    self.tracer = jaeger_tracer
 
                     logger.info("Enabled OpenTracing support with Jaeger")
                 except ModuleNotFoundError:


### PR DESCRIPTION
As the title states, pulls in types for opentracing from `opentracing-types`. Has the added bonus of bumping the mypy precision rate to above 80%.