### PR TITLE
Don't use aioapns 2.1

### DIFF
--- a/changelog.d/294.misc
+++ b/changelog.d/294.misc
@@ -1,0 +1,1 @@
+Avoid a breaking change in aioapns 2.1 by requiring an earlier version of that package.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from typing import Sequence
 from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
-    "aioapns>=1.10",
+    "aioapns>=1.10,<2.1",
     "attrs>=19.2.0",
     "cryptography>=2.6.1",
     "idna>=2.8",


### PR DESCRIPTION
Fixes #293.

aioapns 2.1 made a breaking change: one can no longer pass an event loop directly to APNs.__init__. We could change our code to fix it, but (regrettably) I think it's quicker to avoid using that version. See also https://github.com/matrix-org/sygnal/issues/293#issuecomment-1023453460

I wonder if unit tests would have spotted this? Presumably not.