### PR TITLE
Mark iOS push notifications with `push_type` = `alert` to allow for on device silencing

### DIFF
--- a/changelog.d/305.misc
+++ b/changelog.d/305.misc
@@ -1,0 +1,1 @@
+Mark iOS push notifications with `push_type` = `alert` to allow for on device silencing.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4
 
 import aioapns
-from aioapns import APNs, NotificationRequest
+from aioapns import APNs, NotificationRequest, PushType
 from aioapns.common import NotificationResult
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_pem_x509_certificate
@@ -230,6 +230,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
             message=shaved_payload,
             priority=prio,
             notification_id=notif_id,
+            push_type=PushType.ALERT,
         )
 
         try:


### PR DESCRIPTION
We were recently granted the [com.apple.developer.usernotifications.filtering](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_usernotifications_filtering) entitlement which allows push notifications to be completely discarded once received on the device. This is useful for hiding notifications from encrypted events we don't care about like poll answers (as opposed to showing an empty notification).

One caveat is that it only works for `alert` `apns-push-type` notifications which is an optional field we're not currently setting.
 
This PR does just that through the use of aioapns's [PushType](https://github.com/Fatal1ty/aioapns/blob/master/aioapns/common.py#L9) [header](https://github.com/Fatal1ty/aioapns/blob/master/aioapns/connection.py#L187).