### PR TITLE
Fix test failures by using the latest versions of TLS in the TLS proxy tests.

### DIFF
--- a/changelog.d/306.misc
+++ b/changelog.d/306.misc
@@ -1,0 +1,1 @@
+Fix test failures by using the latest versions of TLS in the TLS proxy tests.

--- a/tests/twisted_test_helpers.py
+++ b/tests/twisted_test_helpers.py
@@ -286,7 +286,7 @@ class TestServerTLSConnectionFactory:
         self._cert_file = create_test_cert_file(sanlist)
 
     def serverConnectionForTLS(self, tlsProtocol):
-        ctx = SSL.Context(SSL.TLSv1_METHOD)
+        ctx = SSL.Context(SSL.SSLv23_METHOD)
         ctx.use_certificate_file(self._cert_file)
         ctx.use_privatekey_file(get_test_key_file())
         return Connection(ctx, None)


### PR DESCRIPTION
See https://github.com/matrix-org/synapse/pull/8208 for the Synapse equivalent.

This is what's causing the current test failures: it appears that OpenSSL configuration has moved on and now forbids TLS v1.0 by default.

This led to errors like
```
twisted.web._newclient.ResponseNeverReceived: [<twisted.python.failure.Failure OpenSSL.SSL.Error: [('SSL routines', '', 'tlsv1 alert internal error')]>]
```

