### PR TITLE
Update the `black` code formatter to 22.3.0.

### DIFF
--- a/changelog.d/307.misc
+++ b/changelog.d/307.misc
@@ -1,0 +1,1 @@
+Update the `black` code formatter to 22.3.0.

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     "dev": [
-        "black==21.6b0",
+        "black==22.3.0",
         "coverage~=5.5",
         "flake8==3.9.0",
         "isort~=5.0",

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -327,7 +327,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
                             log, span, device, shaved_payload, prio
                         )
                 except TemporaryNotificationDispatchException as exc:
-                    retry_delay = self.RETRY_DELAY_BASE * (2 ** retry_number)
+                    retry_delay = self.RETRY_DELAY_BASE * (2**retry_number)
                     if exc.custom_retry_delay is not None:
                         retry_delay = exc.custom_retry_delay
 

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -389,7 +389,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                     if len(pushkeys) == 0:
                         break
                 except TemporaryNotificationDispatchException as exc:
-                    retry_delay = RETRY_DELAY_BASE * (2 ** retry_number)
+                    retry_delay = RETRY_DELAY_BASE * (2**retry_number)
                     if exc.custom_retry_delay is not None:
                         retry_delay = exc.custom_retry_delay
 

--- a/sygnal/helper/proxy/proxyagent_twisted.py
+++ b/sygnal/helper/proxy/proxyagent_twisted.py
@@ -34,7 +34,7 @@ from sygnal.helper.proxy.connectproxyclient_twisted import HTTPConnectProxyEndpo
 
 logger = logging.getLogger(__name__)
 
-_VALID_URI = re.compile(br"\A[\x21-\x7e]+\Z")
+_VALID_URI = re.compile(rb"\A[\x21-\x7e]+\Z")
 
 
 @implementer(IAgent)

--- a/tests/test_apnstruncate.py
+++ b/tests/test_apnstruncate.py
@@ -139,7 +139,7 @@ class TruncateTestCase(unittest.TestCase):
             I have no great desire to manually parse UTF-8 to work around this since
             it works fine on Linux.
         """
-        if len(u"\U0001F430") != 1:
+        if len("\U0001F430") != 1:
             msg = (
                 "Unicode support is broken in your Python binary. "
                 + "Truncating messages with multibyte unicode characters will fail."
@@ -152,7 +152,7 @@ class TruncateTestCase(unittest.TestCase):
         multibyte character.
         """
         overhead = len(json_encode(payload_for_aps({"alert": ""})))
-        txt = u"\U0001F430" + simplestring(30)
+        txt = "\U0001F430" + simplestring(30)
         aps = {"alert": txt}
         # NB. The number of characters of the string we get is dependent
         # on the json encoding used.


### PR DESCRIPTION
This may fix an incompatibility with `click`.
