### PR TITLE
Extend logging for outgoing pushes

### DIFF
--- a/changelog.d/334.misc
+++ b/changelog.d/334.misc
@@ -1,0 +1,1 @@
+Extend logging for outgoing pushes.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -376,7 +376,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                 else:
                     body["registration_ids"] = pushkeys
 
-                log.info("Sending (attempt %i) => %r", retry_number, pushkeys)
+                log.info("Sending (attempt %i) => %r room:%s, event:%s", retry_number, pushkeys, n.room_id, n.event_id)
 
                 try:
                     span_tags = {"retry_num": retry_number}


### PR DESCRIPTION
A bit more logging is useful for being able to diagnose issues. Log the room id and event id for each push, where we have them.