### PR TITLE
Add entrypoint

### DIFF
--- a/changelog.d/341.misc
+++ b/changelog.d/341.misc
@@ -1,0 +1,1 @@
+Add entrypoint to allow running Sygnal by running the `sygnal` script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,6 @@ homepage = "https://github.com/matrix-org/sygnal"
 documentation = "https://github.com/matrix-org/sygnal/tree/main/docs"
 repository = "https://github.com/matrix-org/sygnal.git"
 changelog = "https://github.com/matrix-org/sygnal/blob/main/CHANGELOG.md"
+
+[project.scripts]
+sygnal = "sygnal.sygnal:main"

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -337,7 +337,7 @@ def merge_left_with_defaults(
     return result
 
 
-if __name__ == "__main__":
+def main():
     # TODO we don't want to have to install the reactor, when we can get away with
     #   it
     asyncioreactor.install()
@@ -356,3 +356,7 @@ if __name__ == "__main__":
     custom_reactor = cast(SygnalReactor, asyncioreactor.AsyncioSelectorReactor())
     sygnal = Sygnal(config, custom_reactor)
     sygnal.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows running Sygnal with the `sygnal` command. Also it’s required to have it packaged with Nix’s `buildPythonApplication`, which uses entrypoints to create the executables.