### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -12,6 +12,6 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - run: python -m pip install towncrier
       - run: "scripts-dev/check_newsfragment.sh ${{ github.event.number }}"

--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -12,6 +12,6 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: python -m pip install towncrier
       - run: "scripts-dev/check_newsfragment.sh ${{ github.event.number }}"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: python -m pip install tox
       - run: tox -e check_codestyle
 
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: python -m pip install tox
       - run: tox -e check_types
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - run: python -m pip install -e .
       - run: python -m twisted.trial tests
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,36 +4,36 @@ on:
     branches: ["main"]
   pull_request:
 
-jobs: 
+jobs:
   check-code-style:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - run: python -m pip install tox
       - run: tox -e check_codestyle
-  
+
   check-types-mypy:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
-      - run: python -m pip install tox  
+          python-version: "3.11"
+      - run: python -m pip install tox
       - run: tox -e check_types
 
   run-unit-tests:
     name: Unit tests
     needs: [check-code-style, check-types-mypy]
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - run: python -m pip install -e .
       - run: python -m twisted.trial tests
 
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Patch pyproject.toml to require oldest dependencies
         run: |
           # Ugly. Could use something like https://pyproject-parser.readthedocs.io/en/latest/cli.html#info in the future.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ this case, the [Apache Software License v2](LICENSE).
 
 ### Create a virtualenv
 
-To contribute to Sygnal, ensure you have Python 3.7 or newer and then run:
+To contribute to Sygnal, ensure you have Python 3.8 or newer and then run:
 
 ```bash
 python3 -m venv venv
@@ -17,8 +17,8 @@ This creates an isolated virtual Python environment ("virtualenv") just for
 use with Sygnal, then installs Sygnal along with its dependencies, and lastly
 installs a handful of useful tools
 
-If you get `ConnectTimeoutError`, this is caused by slow internet whereby 
-`pip` has a default time out of _15 sec_. You can specify a larger timeout 
+If you get `ConnectTimeoutError`, this is caused by slow internet whereby
+`pip` has a default time out of _15 sec_. You can specify a larger timeout
 by passing `--timeout 120` to the `pip install` command above.
 
 Finally, activate the virtualenv by running:
@@ -90,7 +90,7 @@ Many of the conventions are enforced by scripts which are run as part of the
 [continuous integration system](#continuous-integration-and-testing).
 
 To help check and fix adherence to the code style, you can run `tox`
-locally. You'll need Python 3.7 or later, and a virtual environment configured and
+locally. You'll need Python 3.8 or later, and a virtual environment configured and
 active:
 
 ```bash
@@ -251,7 +251,7 @@ and update your branch.
 After installing tox with `pip install tox`, you can use the following to run
 unit tests and lints in a local development environment:
 
-- `tox -e py37` to run unit tests on Python 3.7.
+- `tox -e py38` to run unit tests on Python 3.8.
 - `tox -e check_codestyle` to check code style and formatting.
 - `tox -e check_types` to check types with MyPy.
 - `tox` **to do all of the above.**

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ With custom configuration file name:
 SYGNAL_CONF=/path/to/custom_sygnal.conf python -m sygnal.sygnal
 ```
 
-Python 3.7 or higher is required.
+Python 3.8 or higher is required.
 
 
 Log Rotation

--- a/changelog.d/343.misc
+++ b/changelog.d/343.misc
@@ -1,0 +1,1 @@
+Bump Python version to >=3.8.

--- a/changelog.d/343.misc
+++ b/changelog.d/343.misc
@@ -1,1 +1,0 @@
-Bump Python version to >=3.8.

--- a/changelog.d/343.removal
+++ b/changelog.d/343.removal
@@ -1,0 +1,1 @@
+Remove support for Python 3.7.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 ###
 ### Stage 0: builder
 ###
-FROM python:3.11-slim as builder
+FROM python:3.10-slim as builder
 
 # Install git; Sygnal uses it to obtain the package version from the state of the
 # git repository.
@@ -25,7 +25,7 @@ RUN pip install --prefix="/install" --no-warn-script-location /sygnal
 ### Stage 1: runtime
 ###
 
-FROM python:3.11-slim
+FROM python:3.10-slim
 COPY --from=builder /install /usr/local
 
 EXPOSE 5000/tcp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 ###
 ### Stage 0: builder
 ###
-FROM python:3.7-slim as builder
+FROM python:3.11-slim as builder
 
 # Install git; Sygnal uses it to obtain the package version from the state of the
 # git repository.
@@ -25,7 +25,7 @@ RUN pip install --prefix="/install" --no-warn-script-location /sygnal
 ### Stage 1: runtime
 ###
 
-FROM python:3.7-slim
+FROM python:3.11-slim
 COPY --from=builder /install /usr/local
 
 EXPOSE 5000/tcp

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,9 +30,6 @@ ignore_missing_imports = True
 [mypy-prometheus_client]
 ignore_missing_imports = True
 
-[mypy-importlib_metadata]
-ignore_missing_imports = True
-
 [mypy-setuptools]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ name = "matrix-sygnal"
 dynamic = ["version"]
 description = "Reference Push Gateway for Matrix Notifications"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 license = {file = "LICENSE"}
 authors = [
     {name = "Matrix.org Team and contributors", email = "packages@matrix.org"}
@@ -78,7 +78,6 @@ dependencies = [
     "attrs>=19.2.0",
     "cryptography>=2.6.1",
     "idna>=2.8",
-    'importlib_metadata;python_version<"3.8"',
     "jaeger-client>=4.0.0",
     "matrix-common==1.0.0",
     "opentracing>=2.2.0",
@@ -90,7 +89,6 @@ dependencies = [
     "sentry-sdk>=0.10.2",
     "service_identity>=18.1.0",
     "Twisted>=19.7",
-    'typing-extensions>=3.7.4;python_version<"3.8"',
     "zope.interface>=4.6.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     "sentry-sdk>=0.10.2",
     "service_identity>=18.1.0",
     "Twisted>=19.7",
-    "zope.interface>=4.6.0",
+    "zope.interface>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -8,7 +8,7 @@
 #
 log:
   # Specify a Python logging 'dictConfig', as described at:
-  #   https://docs.python.org/3.7/library/logging.config.html#logging.config.dictConfig
+  #   https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig
   #
   setup:
     version: 1
@@ -189,7 +189,7 @@ apps:
   #  #inflight_request_limit: 512
   #
   #  # Specifies whether to use the production or sandbox APNs server. Note that
-  #  # sandbox tokens should only be used with the sandbox server and vice versa. 
+  #  # sandbox tokens should only be used with the sandbox server and vice versa.
   #  #
   #  # Valid options are:
   #  #   * production

--- a/sygnal/__init__.py
+++ b/sygnal/__init__.py
@@ -14,17 +14,6 @@
 # limitations under the License.
 
 try:
-    from importlib.metadata import (  # type: ignore[attr-defined]
-        PackageNotFoundError,
-        version,
-    )
-except ImportError:
-    from importlib_metadata import (  # type: ignore[misc,no-redef]
-        PackageNotFoundError,
-        version,
-    )
-
-try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     # package is not installed

--- a/sygnal/__init__.py
+++ b/sygnal/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib.metadata import PackageNotFoundError, version
+
 try:
     __version__ = version(__name__)
 except PackageNotFoundError:


### PR DESCRIPTION
Python 3.7 is EOL

Python 3.11 is also the Python version of Synapse in Dockerfile

Max Python version here: 3.10.
The upgrade to Python 3.11 seems to need more dependency updates.

```console
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Iast27/Include -I/home/runner/work/sygnal/sygnal/.tox/check_codestyle/include -I/opt/hostedtoolcache/Python/3.11.4/x64/include/python3.11 -c ast27/Custom/typed_ast.c -o build/temp.linux-x86_64-cpython-311/ast27/Custom/typed_ast.o
      In file included from ast27/Custom/typed_ast.c:3:
      ast27/Custom/../Include/compile.h:5:10: fatal error: code.h: No such file or directory
          5 | #include "code.h"
            |          ^~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
```
Possible solutions / causes:
- https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1878635.html
- https://github.com/pre-commit/pre-commit/issues/2850#issuecomment-1519727166

Related to:
- #342 