### PR TITLE
Allow to configure if pushkey should be converted to hex before sending to APNs

### DIFF
--- a/changelog.d/344.feature
+++ b/changelog.d/344.feature
@@ -1,1 +1,1 @@
-Add a new `convert_device_token_to_hex` configuration option for APNs apps, to allow disabling the conversion of device tokens from base64 to hex. (#344)
+Add a new `convert_device_token_to_hex` configuration option for APNs apps, to allow disabling the conversion of device tokens from base64 to hex.

--- a/changelog.d/344.feature
+++ b/changelog.d/344.feature
@@ -1,0 +1,1 @@
+Add a new `convert_device_token_to_hex` configuration option for APNs apps, to allow disabling the conversion of device tokens from base64 to hex. (#344)

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -197,6 +197,11 @@ apps:
   #  #
   #  # The default is 'production'. Uncomment to use the sandbox instance.
   #  #platform: sandbox
+  #  #
+  #  # Specifies whether to use a hexadecimally encoded push token. If True
+  #  # (default) the pushkey received is trancoded from base64 to hex. If False
+  #  # the pushkey received is passed to APNs as is.
+  #  #apns_device_token_use_hex: false
 
   # This is an example GCM/FCM push configuration.
   #

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -198,9 +198,9 @@ apps:
   #  # The default is 'production'. Uncomment to use the sandbox instance.
   #  #platform: sandbox
   #  #
-  #  # Specifies whether to use a hexadecimally encoded push token. If True
-  #  # (default) the pushkey received is trancoded from base64 to hex. If False
-  #  # the pushkey received is passed to APNs as is.
+  #  # Specifies whether to convert the device push token from base 64 to hex.
+  #  # Defaults to True, set this to False if your client library provides a
+  #  # push token in hex format.
   #  #apns_device_token_use_hex: false
 
   # This is an example GCM/FCM push configuration.

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -201,7 +201,7 @@ apps:
   #  # Specifies whether to convert the device push token from base 64 to hex.
   #  # Defaults to True, set this to False if your client library provides a
   #  # push token in hex format.
-  #  #apns_device_token_use_hex: false
+  #  #convert_device_token_to_hex: false
 
   # This is an example GCM/FCM push configuration.
   #

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -242,7 +242,10 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         log.info(f"Sending as APNs-ID {notif_id}")
         span.set_tag("apns_id", notif_id)
 
-        device_token = base64.b64decode(device.pushkey).hex()
+        if self.get_config("apns_device_token_use_hex", bool, True):
+            device_token = base64.b64decode(device.pushkey).hex()
+        else:
+            device_token = device.pushkey
 
         request = NotificationRequest(
             device_token=device_token,

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -244,7 +244,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
 
         # Some client libraries will provide the push token in hex format already. Avoid
         # attempting to convert from base 64 to hex.
-        if self.get_config("apns_device_token_use_hex", bool, True):
+        if self.get_config("convert_device_token_to_hex", bool, True):
             device_token = base64.b64decode(device.pushkey).hex()
         else:
             device_token = device.pushkey

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -242,6 +242,8 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         log.info(f"Sending as APNs-ID {notif_id}")
         span.set_tag("apns_id", notif_id)
 
+        # Some client libraries will provide the push token in hex format already. Avoid
+        # attempting to convert from base 64 to hex.
         if self.get_config("apns_device_token_use_hex", bool, True):
             device_token = base64.b64decode(device.pushkey).hex()
         else:


### PR DESCRIPTION
I ran into the same problem as https://github.com/matrix-org/sygnal/issues/301 and decided to instead make this configurable in Sygnal. Not sure if this is the right approach, happy for feedback and adopting to something else :)

Signed-off-by: Daniel Bimschas <daniel@bimschas.com> / <daniel.bimschas@inoio.de>