### PR TITLE
Update aioapns dependency to one that supports python 3.10+

### DIFF
--- a/changelog.d/347.misc
+++ b/changelog.d/347.misc
@@ -1,0 +1,1 @@
+Bump aioapns dependency to 3.0 in order to support Python 3.10+

--- a/changelog.d/347.misc
+++ b/changelog.d/347.misc
@@ -1,1 +1,1 @@
-Bump aioapns dependency to 3.0 in order to support Python 3.10+
+Bump aioapns dependency to 3.0 in order to support Python 3.10+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ authors = [
     {name = "Matrix.org Team and contributors", email = "packages@matrix.org"}
 ]
 dependencies = [
-    "aioapns>=1.10,<2.1",
+    "aioapns>=3.0",
     "attrs>=19.2.0",
     "cryptography>=2.6.1",
     "idna>=2.8",

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -172,31 +172,34 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
             # this overrides the create_connection method to use a HTTP proxy
             loop = ProxyingEventLoopWrapper(loop, proxy_url_str)  # type: ignore
 
-        if certfile is not None:
-            # max_connection_attempts is actually the maximum number of
-            # additional connection attempts, so =0 means try once only
-            # (we will retry at a higher level so not worth doing more here)
-            self.apns_client = APNs(
-                client_cert=certfile,
-                use_sandbox=self.use_sandbox,
-                max_connection_attempts=0,
-                loop=loop,
-            )
+        async def make_apns() -> aioapns.APNs:
+            if certfile is not None:
+                # max_connection_attempts is actually the maximum number of
+                # additional connection attempts, so =0 means try once only
+                # (we will retry at a higher level so not worth doing more here)
+                apns_client = APNs(
+                    client_cert=certfile,
+                    use_sandbox=self.use_sandbox,
+                    max_connection_attempts=0,
+                )
 
-            self._report_certificate_expiration(certfile)
-        else:
-            # max_connection_attempts is actually the maximum number of
-            # additional connection attempts, so =0 means try once only
-            # (we will retry at a higher level so not worth doing more here)
-            self.apns_client = APNs(
-                key=self.get_config("keyfile", str),
-                key_id=self.get_config("key_id", str),
-                team_id=self.get_config("team_id", str),
-                topic=self.get_config("topic", str),
-                use_sandbox=self.use_sandbox,
-                max_connection_attempts=0,
-                loop=loop,
-            )
+                self._report_certificate_expiration(certfile)
+
+                return apns_client
+            else:
+                # max_connection_attempts is actually the maximum number of
+                # additional connection attempts, so =0 means try once only
+                # (we will retry at a higher level so not worth doing more here)
+                return APNs(
+                    key=self.get_config("keyfile", str),
+                    key_id=self.get_config("key_id", str),
+                    team_id=self.get_config("team_id", str),
+                    topic=self.get_config("topic", str),
+                    use_sandbox=self.use_sandbox,
+                    max_connection_attempts=0,
+                )
+
+        self.apns_client = loop.run_until_complete(make_apns())
 
         push_type = self.get_config("push_type", str)
         if not push_type:

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -265,7 +265,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
             return []
         else:
             # .description corresponds to the 'reason' response field
-            span.set_tag("apns_reason", response.description)
+            span.set_tag("apns_reason", response.description or "None")
             if (code, response.description) in self.TOKEN_ERRORS:
                 log.info(
                     "APNs token %s for pushkin %s was rejected: %d %s",


### PR DESCRIPTION
I believe apns support has been broken since https://github.com/matrix-org/sygnal/pull/343, see comment https://github.com/matrix-org/sygnal/pull/343#issuecomment-1707191931

This brings us to the latest version of aioapns and fixes it to work on newer version of Python.