### PR TITLE
Lookup Sygnal version using the correct name

### DIFF
--- a/changelog.d/355.bugfix
+++ b/changelog.d/355.bugfix
@@ -1,0 +1,1 @@
+Fix a bug introduced in Sygnal 0.5.0 where `sygnal.__version__` would not be correctly populated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ dependencies = [
     "pyyaml>=5.1.1",
     "sentry-sdk>=0.10.2",
     "service_identity>=18.1.0",
-    "Twisted>=19.7",
+    # Upper bound: tests fail on latest Twisted, see https://github.com/matrix-org/sygnal/issues/356
+    "Twisted>=19.7,<23.10",
     "zope.interface>=5.0.0",
 ]
 

--- a/sygnal/__init__.py
+++ b/sygnal/__init__.py
@@ -16,7 +16,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version(__name__)
+    __version__ = version("matrix-sygnal")
 except PackageNotFoundError:
     # package is not installed
     pass


### PR DESCRIPTION
We passed it a module name [1] instead of the "distribution name"(?)

Broken in 0ced8bda3c759b1584d327205245162da64488a4, so Sygnal 0.5.0.

[1]: https://docs.python.org/3/reference/import.html#name__

Fixes #354.