### PR TITLE
Add a new APNs configuration option `push_with_badge` to suppress sending `aps.badge` in APNs messages.

### DIFF
--- a/changelog.d/356.feature
+++ b/changelog.d/356.feature
@@ -1,0 +1,1 @@
+Add a new APNs configuration option `push_with_badge` to suppress sending `aps.badge` in APNs messages.

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -202,6 +202,10 @@ apps:
   #  # Defaults to True, set this to False if your client library provides a
   #  # push token in hex format.
   #  #convert_device_token_to_hex: false
+  #  #
+  #  # Specifies whether to send the badge key in the APNs message.
+  #  # Defaults to True, set this to False to suppress sending the badge count.
+  #  #push_with_badge: false
 
   # This is an example GCM/FCM push configuration.
   #

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -110,6 +110,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         "keyfile",
         "topic",
         "push_type",
+        "push_with_badge",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     APNS_PUSH_TYPES = {
@@ -551,13 +552,19 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         if loc_args:
             payload["aps"].setdefault("alert", {})["loc-args"] = loc_args
 
-        if badge is not None:
+        if self.get_config("push_with_badge", bool, True) and badge is not None:
             payload["aps"]["badge"] = badge
 
         if loc_key and n.room_id:
             payload["room_id"] = n.room_id
         if loc_key and n.event_id:
             payload["event_id"] = n.event_id
+
+        if not self.get_config("push_with_badge", bool, True):
+            if n.counts.unread is not None:
+                payload["unread_count"] = n.counts.unread
+            if n.counts.missed_calls is not None:
+                payload["missed_calls"] = n.counts.missed_calls
 
         return payload
 


### PR DESCRIPTION
For situations when not using `mutable-content` and updating the badge count is not desired.
This also adds `unread_count` and `missed_calls` to the push payload when `push_with_badge` is `False`.