### PR TITLE
Explicitly configure the aioapns event loop so proxying works when configured

### DIFF
--- a/changelog.d/360.bugfix
+++ b/changelog.d/360.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue which resulted in proxy configuration being ignored for APNs notifications.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -213,6 +213,9 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         # without this, aioapns will retry every second forever.
         self.apns_client.pool.max_connection_attempts = 3
 
+        # without this, aioapns will not use the proxy if one is configured.
+        self.apns_client.pool.loop = loop
+
     def _report_certificate_expiration(self, certfile: str) -> None:
         """Export the epoch time that the certificate expires as a metric."""
         with open(certfile, "rb") as f:


### PR DESCRIPTION
When the aioapns dependency was updated, they removed the ability to inject an event loop.
This change sets the event loop manually after creating the apns client.

We use a custom event loop in this case in order to override `create_connection` when a proxy is configured to force all traffic over the proxy.

Fixes https://github.com/element-hq/backend-internal/issues/22