### PR TITLE
Check if `data["content"]` is a dict before using it as a dict

### DIFF
--- a/changelog.d/362.bugfix
+++ b/changelog.d/362.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing Sygnal to fail when processing notifications without a `content` dict, when those notifications were destined for GCM. Contributed by @c-cal.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -669,7 +669,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                     data[attr] = data[attr][0:MAX_BYTES_PER_FIELD]
 
         if api_version is APIVersion.V1:
-            if "content" in data:
+            if isinstance(data.get("content"), dict):
                 for attr, value in data["content"].items():
                     if not isinstance(value, str):
                         continue


### PR DESCRIPTION
Fix https://github.com/matrix-org/sygnal/issues/363

![image](https://github.com/matrix-org/sygnal/assets/57274151/ff418b22-fadd-4c02-9a19-52d6019ce75c)

When notification does not contain the "content" field, then `None` is used by default:
https://github.com/matrix-org/sygnal/blob/c8a85fd3e9009ff21a79089a4f3524cc0e310024/sygnal/notifications.py#L95

This happens with pusher that have the attribute `data.format: event_id_only`, such as Element Android (https://github.com/element-hq/element-android/blob/develop/vector/src/main/java/im/vector/app/core/pushers/PushersManager.kt#L85), or when Synapse is configured with `push.include_content: false`.

Signed-off-by: Charlie Calendre