### PR TITLE
Allow convert_device_token_to_hex apns config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ For either type, it can accept:
   Valid values are 'production' or 'sandbox'. If not provided, 'production' is used.
 - the `push_type` parameter which determines what value for the `apns-push-type` header is sent to
   APNs. If not provided, the header is not sent.
+- the `convert_device_token_to_hex` parameter which determines if the
+  token provided from the client is b64 decoded and converted to
+  hex. Some client libraries already provide the token in hex, and
+  this should be set to `False` if so.
 
 ### gcm
 

--- a/changelog.d/364.bugfix
+++ b/changelog.d/364.bugfix
@@ -1,0 +1,1 @@
+Add convert_device_token_to_hex to the list of understood APNs config parameters.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -110,6 +110,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         "keyfile",
         "topic",
         "push_type",
+        "convert_device_token_to_hex",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     APNS_PUSH_TYPES = {


### PR DESCRIPTION
`convert_device_token_to_hex` is currently supported, however the option is not in the list of understood APNs parameters. This PR adds it to the understood params.