### PR TITLE
Update docker build and workflows to Python 3.11

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -12,6 +12,6 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install towncrier
       - run: "scripts-dev/check_newsfragment.sh ${{ github.event.number }}"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install tox
       - run: tox -e check_codestyle
 
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install tox
       - run: tox -e check_types
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install -e .
       - run: python -m twisted.trial tests
 

--- a/changelog.d/373.misc
+++ b/changelog.d/373.misc
@@ -1,0 +1,1 @@
+Update docker build and CI workflows to Python 3.11.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 ###
 ### Stage 0: builder
 ###
-FROM python:3.10-slim as builder
+FROM python:3.11-slim as builder
 
 # Install git; Sygnal uses it to obtain the package version from the state of the
 # git repository.
@@ -25,7 +25,7 @@ RUN pip install --prefix="/install" --no-warn-script-location /sygnal
 ### Stage 1: runtime
 ###
 
-FROM python:3.10-slim
+FROM python:3.11-slim
 COPY --from=builder /install /usr/local
 
 EXPOSE 5000/tcp


### PR DESCRIPTION
Python 3.11 is now old enough to be considered pretty stable I believe, and it has major perfs improvement.

Moreover it supports [TLS-in-TLS](https://github.com/aio-libs/aiohttp/discussions/6044), enabling support for HTTPS proxy for FCM v1 API, which use `google-auth` with `aiohttp`.