### PR TITLE
Add manual proxy testing setup scripts & notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,26 @@ unit tests and lints in a local development environment:
 - `tox -e check_types` to check types with MyPy.
 - `tox` **to do all of the above.**
 
+### Testing proxy support
+
+To test whether proxy support is working or not, a docker compose file has been
+provided to make things easier.
+
+For GCM Pushkin proxy testing follow these steps:
+- create a firebase project & service account
+- download the service account file from firebase & save to `./scripts-dev/proxy-test/service_account.json`
+- configure the PROJECT_ID in `./scripts-dev/proxy-test/sygnal.yaml`
+- cd to `./scripts-dev/proxy-test/`
+- run `docker compose up`
+- in another terminal, run `docker exec -it sygnal bash`
+- run `apt update && apt install curl -y`
+- run `chmod +x curl.sh`
+- run `./curl.sh`
+- you can tell if the proxy is **NOT** working by inspecting the sygnal logs & seeing something along the lines of "Network is unreachable" or DNS resolution/proxy errors
+- you cal tell if the proxy is working by inspecting the sygnal logs & seeing the following error from firebase '"code": 400, "message": "The registration token is not a valid FCM registration token"'
+- this is due to the `pushkey` being set to PUSHKEY_HERE in `notification.json`
+- if you want to fully test an actual notification, you will have to update this value in `./scripts-dev/proxy-test/notification.json` before calling `docker compose up`
+
 ## Updating your pull request
 
 If you decide to make changes to your pull request - perhaps to address issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,6 +265,7 @@ For GCM Pushkin proxy testing follow these steps:
 - create a firebase project & service account
 - download the service account file from firebase & save to `./scripts-dev/proxy-test/service_account.json`
 - configure the PROJECT_ID in `./scripts-dev/proxy-test/sygnal.yaml`
+- build a docker image of sygnal named `sygnal`
 - cd to `./scripts-dev/proxy-test/`
 - run `docker compose up`
 - in another terminal, run `docker exec -it sygnal bash`

--- a/changelog.d/375.misc
+++ b/changelog.d/375.misc
@@ -1,0 +1,1 @@
+Add manual proxy testing scripts & docs.

--- a/scripts-dev/proxy-test/curl.sh
+++ b/scripts-dev/proxy-test/curl.sh
@@ -1,0 +1,1 @@
+curl -i -H "Content-Type: application/json" --request POST -d @notification.json http://localhost:5000/_matrix/push/v1/notify

--- a/scripts-dev/proxy-test/docker-compose.yml
+++ b/scripts-dev/proxy-test/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  sygnal:
+    image: sygnal
+    networks:
+      - no-internet
+    container_name: sygnal
+    volumes:
+      - ./sygnal.yaml:/sygnal.yaml
+      - ./<SERVICE_ACCOUNT_FILE>.json:/service_account.json:ro
+    ports:
+      - 5000:5000
+
+  proxy:
+    image: dominikbechstein/nginx-forward-proxy
+    networks:
+      - no-internet
+      - internet
+    container_name: nginx-forward-proxy
+    volumes:
+      - ./nginx.conf:/usr/local/nginx/conf/nginx.conf:ro
+    ports:
+      - 8080:8080
+
+networks:
+  no-internet:
+    driver: bridge
+    internal: true
+  internet:
+    driver: bridge

--- a/scripts-dev/proxy-test/docker-compose.yml
+++ b/scripts-dev/proxy-test/docker-compose.yml
@@ -2,19 +2,24 @@ services:
   sygnal:
     image: sygnal
     networks:
-      - no-internet
+      no-internet:
+        ipv4_address: 172.28.0.2
     container_name: sygnal
     volumes:
       - ./sygnal.yaml:/sygnal.yaml
-      - ./<SERVICE_ACCOUNT_FILE>.json:/service_account.json:ro
+      - ./service_account.json:/service_account.json:ro
+      - ./curl.sh:/curl.sh
+      - ./notification.json:/notification.json
+      - ./proxy.conf:/etc/apt/apt.conf.d/proxy.conf
     ports:
       - 5000:5000
 
   proxy:
     image: dominikbechstein/nginx-forward-proxy
     networks:
-      - no-internet
-      - internet
+      no-internet:
+        ipv4_address: 172.28.0.3
+      internet:
     container_name: nginx-forward-proxy
     volumes:
       - ./nginx.conf:/usr/local/nginx/conf/nginx.conf:ro
@@ -25,5 +30,9 @@ networks:
   no-internet:
     driver: bridge
     internal: true
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16
+          gateway: 172.28.0.1
   internet:
     driver: bridge

--- a/scripts-dev/proxy-test/nginx.conf
+++ b/scripts-dev/proxy-test/nginx.conf
@@ -1,0 +1,44 @@
+worker_processes auto;
+
+daemon off;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include mime.types;
+
+  access_log /dev/stdout;
+  error_log  /dev/stderr;
+
+  server {
+    listen 8080;
+
+    resolver 1.1.1.1 ipv6=off;
+
+    proxy_connect;
+    proxy_connect_allow           443 563;
+    proxy_connect_connect_timeout 10s;
+    proxy_connect_read_timeout    10s;
+    proxy_connect_send_timeout    10s;
+
+    proxy_hide_header Upgrade;
+    proxy_hide_header X-Powered-By;
+
+    add_header Content-Security-Policy "upgrade-insecure-requests";
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Cache-Control "no-transform" always;
+    add_header Referrer-Policy no-referrer always;
+    add_header X-Robots-Tag none;
+
+    location / {
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_pass $scheme://$host;
+    }
+  }
+}
+

--- a/scripts-dev/proxy-test/notification.json
+++ b/scripts-dev/proxy-test/notification.json
@@ -1,0 +1,31 @@
+{
+  "notification": {
+    "event_id": "\\$3957tyerfgewrf384",
+    "room_id": "!slw48wfj34rtnrf:example.org",
+    "type": "m.room.message",
+    "sender": "@exampleuser:example.org",
+    "sender_display_name": "Major Tom",
+    "room_name": "Mission Control",
+    "room_alias": "#exampleroom:example.org",
+    "prio": "high",
+    "content": {
+      "msgtype": "m.text",
+      "body": "I'm floating in a most peculiar way."
+    },
+    "counts": {
+      "unread": 2,
+      "missed_calls": 1
+    },
+    "devices": [
+      {
+        "app_id": "im.vector.app",
+        "pushkey": "<PUSHKEY HERE>",
+        "pushkey_ts": 12345678,
+        "data": {},
+        "tweaks": {
+          "sound": "bing"
+        }
+      }
+    ]
+  }
+}

--- a/scripts-dev/proxy-test/proxy.conf
+++ b/scripts-dev/proxy-test/proxy.conf
@@ -1,0 +1,1 @@
+Acquire::http::Proxy "http://172.28.0.3:8080/";

--- a/scripts-dev/proxy-test/sygnal.yaml
+++ b/scripts-dev/proxy-test/sygnal.yaml
@@ -1,0 +1,247 @@
+##
+# This is a configuration for Sygnal, the reference Push Gateway for Matrix
+# See: matrix.org
+##
+
+
+## Logging #
+#
+log:
+  # Specify a Python logging 'dictConfig', as described at:
+  #   https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig
+  #
+  setup:
+    version: 1
+    formatters:
+      normal:
+        format: "%(asctime)s [%(process)d] %(levelname)-5s %(name)s %(message)s"
+    handlers:
+      # This handler prints to Standard Error
+      #
+      stderr:
+        class: "logging.StreamHandler"
+        formatter: "normal"
+        stream: "ext://sys.stderr"
+
+      # This handler prints to Standard Output.
+      #
+      stdout:
+        class: "logging.StreamHandler"
+        formatter: "normal"
+        stream: "ext://sys.stdout"
+
+      # This handler demonstrates logging to a text file on the filesystem.
+      # You can use logrotate(8) to perform log rotation.
+      #
+      file:
+        class: "logging.handlers.WatchedFileHandler"
+        formatter: "normal"
+        filename: "./sygnal.log"
+    loggers:
+      # sygnal.access contains the access logging lines.
+      # Comment out this section if you don't want to give access logging
+      # any special treatment.
+      #
+      sygnal.access:
+        propagate: false
+        handlers: ["stdout"]
+        level: "INFO"
+
+      # sygnal contains log lines from Sygnal itself.
+      # You can comment out this section to fall back to the root logger.
+      #
+      sygnal:
+        propagate: false
+        handlers: ["stderr", "file"]
+
+    root:
+      # Specify the handler(s) to send log messages to.
+      handlers: ["stderr"]
+      level: "INFO"
+
+    disable_existing_loggers: false
+
+
+  access:
+    # Specify whether or not to trust the IP address in the `X-Forwarded-For`
+    # header. In general, you want to enable this if and only if you are using a
+    # reverse proxy which is configured to emit it.
+    #
+    x_forwarded_for: false
+
+## HTTP Server (Matrix Push Gateway API) #
+#
+http:
+  # Specify a list of interface addresses to bind to.
+  #
+  # This example listens on the IPv4 loopback device:
+  bind_addresses: ['127.0.0.1']
+  # This example listens on all IPv4 interfaces:
+  #bind_addresses: ['0.0.0.0']
+  # This example listens on all IPv4 and IPv6 interfaces:
+  #bind_addresses: ['0.0.0.0', '::']
+
+  # Specify the port number to listen on.
+  #
+  port: 5000
+
+## Proxying for outgoing connections #
+#
+# Specify the URL of a proxy to use for outgoing traffic
+# (e.g. to Apple & Google) if desired.
+# Currently only HTTP proxies with CONNECT capability are supported.
+#
+# If you do not specify a value, the `HTTPS_PROXY` environment variable will
+# be used if present. Otherwise, no proxy will be used.
+#
+# Default is unspecified.
+#
+proxy: 'http://<PROXY_CONTAINER_IP>:8080'
+
+## Metrics #
+#
+metrics:
+  ## Prometheus #
+  #
+  prometheus:
+    # Specify whether or not to enable Prometheus.
+    #
+    enabled: false
+
+    # Specify an address for the Prometheus HTTP Server to listen on.
+    #
+    address: '127.0.0.1'
+
+    # Specify a port for the Prometheus HTTP Server to listen on.
+    #
+    port: 8000
+
+  ## OpenTracing #
+  #
+  opentracing:
+    # Specify whether or not to enable OpenTracing.
+    #
+    enabled: false
+
+    # Specify an implementation of OpenTracing to use. Currently only 'jaeger'
+    # is supported.
+    #
+    implementation: jaeger
+
+    # Specify the service name to be reported to the tracer.
+    #
+    service_name: sygnal
+
+    # Specify configuration values to pass to jaeger_client.
+    #
+    jaeger:
+      sampler:
+        type: 'const'
+        param: 1
+#        local_agent:
+#          reporting_host: '127.0.0.1'
+#          reporting_port:
+      logging: true
+
+  ## Sentry #
+  #
+  sentry:
+    # Specify whether or not to enable Sentry.
+    #
+    enabled: false
+
+    # Specify your Sentry DSN if you enable Sentry
+    #
+    #dsn: "https://<key>@sentry.example.org/<project>"
+
+## Pushkins/Apps #
+#
+# Add a section for every push application here.
+# Specify the pushkey for the application and also the type.
+# For the type, you may specify a fully-qualified Python classname if desired.
+#
+apps:
+  # This is an example APNs push configuration
+  #
+  #com.example.myapp.ios:
+  #  type: apns
+  #
+  #  # Authentication
+  #  #
+  #  # Two methods of authentication to APNs are currently supported.
+  #  #
+  #  # You can authenticate using a key:
+  #  keyfile: my_key.p8
+  #  key_id: MY_KEY_ID
+  #  team_id: MY_TEAM_ID
+  #  topic: MY_TOPIC
+  #
+  #  # Or, a certificate can be used instead:
+  #  certfile: com.example.myApp_prod_APNS.pem
+  #
+  #  # This is the maximum number of in-flight requests *for this pushkin*
+  #  # before additional notifications will be failed.
+  #  # (This is a robustness measure to prevent one pushkin stacking up with
+  #  #  queued requests and saturating the inbound connection queue of a load
+  #  #  balancer or reverse proxy).
+  #  # Defaults to 512 if unset.
+  #  #
+  #  #inflight_request_limit: 512
+  #
+  #  # Specifies whether to use the production or sandbox APNs server. Note that
+  #  # sandbox tokens should only be used with the sandbox server and vice versa.
+  #  #
+  #  # Valid options are:
+  #  #   * production
+  #  #   * sandbox
+  #  #
+  #  # The default is 'production'. Uncomment to use the sandbox instance.
+  #  #platform: sandbox
+  #  #
+  #  # Specifies whether to convert the device push token from base 64 to hex.
+  #  # Defaults to True, set this to False if your client library provides a
+  #  # push token in hex format.
+  #  #convert_device_token_to_hex: false
+
+  # This is an example GCM/FCM push configuration.
+  #
+  im.vector.app:
+    type: gcm
+    api_version: v1
+    project_id: <PROJECT_ID>
+    service_account_file: /service_account.json
+  
+    # This is the maximum number of connections to GCM servers at any one time
+    # the default is 20.
+    #max_connections: 20
+  
+    # This is the maximum number of in-flight requests *for this pushkin*
+    # before additional notifications will be failed.
+    # (This is a robustness measure to prevent one pushkin stacking up with
+    #  queued requests and saturating the inbound connection queue of a load
+    #  balancer or reverse proxy).
+    # Defaults to 512 if unset.
+    #
+    #inflight_request_limit: 512
+  
+    # This allows you to specify additional options to send to Firebase.
+    #
+    # Of particular interest, admins who wish to support iOS apps using Firebase
+    # probably wish to set content-available, and may need to set mutable-content.
+    # (content-available allows your iOS app to be woken up by data messages,
+    # and mutable-content allows your notification to be modified by a
+    # Notification Service app extension).
+    #
+    # See https://firebase.google.com/docs/cloud-messaging/http-server-ref
+    # for the exhaustive list of valid options.
+    #
+    # Do not specify `data`, `priority`, `to` or `registration_ids` as they may
+    # be overwritten or lead to an invalid request.
+    #
+    #fcm_options:
+    #  apns:
+    #    payload:
+    #      aps:
+    #        content-available: 1
+    #        mutable-content: 1
+    #        alert: ""

--- a/scripts-dev/proxy-test/sygnal.yaml
+++ b/scripts-dev/proxy-test/sygnal.yaml
@@ -1,247 +1,66 @@
 ##
 # This is a configuration for Sygnal, the reference Push Gateway for Matrix
-# See: matrix.org
 ##
 
-
-## Logging #
-#
 log:
-  # Specify a Python logging 'dictConfig', as described at:
-  #   https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig
-  #
   setup:
     version: 1
     formatters:
       normal:
         format: "%(asctime)s [%(process)d] %(levelname)-5s %(name)s %(message)s"
     handlers:
-      # This handler prints to Standard Error
-      #
       stderr:
         class: "logging.StreamHandler"
         formatter: "normal"
         stream: "ext://sys.stderr"
 
-      # This handler prints to Standard Output.
-      #
       stdout:
         class: "logging.StreamHandler"
         formatter: "normal"
         stream: "ext://sys.stdout"
 
-      # This handler demonstrates logging to a text file on the filesystem.
-      # You can use logrotate(8) to perform log rotation.
-      #
       file:
         class: "logging.handlers.WatchedFileHandler"
         formatter: "normal"
         filename: "./sygnal.log"
     loggers:
-      # sygnal.access contains the access logging lines.
-      # Comment out this section if you don't want to give access logging
-      # any special treatment.
-      #
       sygnal.access:
         propagate: false
         handlers: ["stdout"]
         level: "INFO"
 
-      # sygnal contains log lines from Sygnal itself.
-      # You can comment out this section to fall back to the root logger.
-      #
       sygnal:
         propagate: false
         handlers: ["stderr", "file"]
 
     root:
-      # Specify the handler(s) to send log messages to.
       handlers: ["stderr"]
       level: "INFO"
 
     disable_existing_loggers: false
 
-
   access:
-    # Specify whether or not to trust the IP address in the `X-Forwarded-For`
-    # header. In general, you want to enable this if and only if you are using a
-    # reverse proxy which is configured to emit it.
-    #
     x_forwarded_for: false
 
-## HTTP Server (Matrix Push Gateway API) #
-#
 http:
-  # Specify a list of interface addresses to bind to.
-  #
-  # This example listens on the IPv4 loopback device:
   bind_addresses: ['127.0.0.1']
-  # This example listens on all IPv4 interfaces:
-  #bind_addresses: ['0.0.0.0']
-  # This example listens on all IPv4 and IPv6 interfaces:
-  #bind_addresses: ['0.0.0.0', '::']
-
-  # Specify the port number to listen on.
-  #
   port: 5000
 
-## Proxying for outgoing connections #
-#
-# Specify the URL of a proxy to use for outgoing traffic
-# (e.g. to Apple & Google) if desired.
-# Currently only HTTP proxies with CONNECT capability are supported.
-#
-# If you do not specify a value, the `HTTPS_PROXY` environment variable will
-# be used if present. Otherwise, no proxy will be used.
-#
-# Default is unspecified.
-#
-proxy: 'http://<PROXY_CONTAINER_IP>:8080'
+proxy: 'http://172.28.0.3:8080'
 
-## Metrics #
-#
 metrics:
-  ## Prometheus #
-  #
   prometheus:
-    # Specify whether or not to enable Prometheus.
-    #
     enabled: false
 
-    # Specify an address for the Prometheus HTTP Server to listen on.
-    #
-    address: '127.0.0.1'
-
-    # Specify a port for the Prometheus HTTP Server to listen on.
-    #
-    port: 8000
-
-  ## OpenTracing #
-  #
   opentracing:
-    # Specify whether or not to enable OpenTracing.
-    #
     enabled: false
 
-    # Specify an implementation of OpenTracing to use. Currently only 'jaeger'
-    # is supported.
-    #
-    implementation: jaeger
-
-    # Specify the service name to be reported to the tracer.
-    #
-    service_name: sygnal
-
-    # Specify configuration values to pass to jaeger_client.
-    #
-    jaeger:
-      sampler:
-        type: 'const'
-        param: 1
-#        local_agent:
-#          reporting_host: '127.0.0.1'
-#          reporting_port:
-      logging: true
-
-  ## Sentry #
-  #
   sentry:
-    # Specify whether or not to enable Sentry.
-    #
     enabled: false
 
-    # Specify your Sentry DSN if you enable Sentry
-    #
-    #dsn: "https://<key>@sentry.example.org/<project>"
-
-## Pushkins/Apps #
-#
-# Add a section for every push application here.
-# Specify the pushkey for the application and also the type.
-# For the type, you may specify a fully-qualified Python classname if desired.
-#
 apps:
-  # This is an example APNs push configuration
-  #
-  #com.example.myapp.ios:
-  #  type: apns
-  #
-  #  # Authentication
-  #  #
-  #  # Two methods of authentication to APNs are currently supported.
-  #  #
-  #  # You can authenticate using a key:
-  #  keyfile: my_key.p8
-  #  key_id: MY_KEY_ID
-  #  team_id: MY_TEAM_ID
-  #  topic: MY_TOPIC
-  #
-  #  # Or, a certificate can be used instead:
-  #  certfile: com.example.myApp_prod_APNS.pem
-  #
-  #  # This is the maximum number of in-flight requests *for this pushkin*
-  #  # before additional notifications will be failed.
-  #  # (This is a robustness measure to prevent one pushkin stacking up with
-  #  #  queued requests and saturating the inbound connection queue of a load
-  #  #  balancer or reverse proxy).
-  #  # Defaults to 512 if unset.
-  #  #
-  #  #inflight_request_limit: 512
-  #
-  #  # Specifies whether to use the production or sandbox APNs server. Note that
-  #  # sandbox tokens should only be used with the sandbox server and vice versa.
-  #  #
-  #  # Valid options are:
-  #  #   * production
-  #  #   * sandbox
-  #  #
-  #  # The default is 'production'. Uncomment to use the sandbox instance.
-  #  #platform: sandbox
-  #  #
-  #  # Specifies whether to convert the device push token from base 64 to hex.
-  #  # Defaults to True, set this to False if your client library provides a
-  #  # push token in hex format.
-  #  #convert_device_token_to_hex: false
-
-  # This is an example GCM/FCM push configuration.
-  #
   im.vector.app:
     type: gcm
     api_version: v1
     project_id: <PROJECT_ID>
     service_account_file: /service_account.json
-  
-    # This is the maximum number of connections to GCM servers at any one time
-    # the default is 20.
-    #max_connections: 20
-  
-    # This is the maximum number of in-flight requests *for this pushkin*
-    # before additional notifications will be failed.
-    # (This is a robustness measure to prevent one pushkin stacking up with
-    #  queued requests and saturating the inbound connection queue of a load
-    #  balancer or reverse proxy).
-    # Defaults to 512 if unset.
-    #
-    #inflight_request_limit: 512
-  
-    # This allows you to specify additional options to send to Firebase.
-    #
-    # Of particular interest, admins who wish to support iOS apps using Firebase
-    # probably wish to set content-available, and may need to set mutable-content.
-    # (content-available allows your iOS app to be woken up by data messages,
-    # and mutable-content allows your notification to be modified by a
-    # Notification Service app extension).
-    #
-    # See https://firebase.google.com/docs/cloud-messaging/http-server-ref
-    # for the exhaustive list of valid options.
-    #
-    # Do not specify `data`, `priority`, `to` or `registration_ids` as they may
-    # be overwritten or lead to an invalid request.
-    #
-    #fcm_options:
-    #  apns:
-    #    payload:
-    #      aps:
-    #        content-available: 1
-    #        mutable-content: 1
-    #        alert: ""


### PR DESCRIPTION
The full procedure to perform manual proxy testing is provided in CONTRIBUTING.md.
The files provided aim to make the setup as simple and with as few input requirements as possible.

Ideally we would run something like this in CI, but that would require putting a legitimate firebase project & service_account info in CI as well. 