### PR TITLE
v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Sygnal 0.14.2 (2024-05-21)
+
+### Bugfixes
+
+- FCM v1: use async version of google-auth and add HTTP proxy support. ([\#372](https://github.com/matrix-org/sygnal/issues/372))
+
+### Improved Documentation
+
+- Update docs & tests to reflect APNs usage in FCM v1 API. ([\#370](https://github.com/matrix-org/sygnal/issues/370))
+
+### Internal Changes
+
+- Update docker build and CI workflows to Python 3.11. ([\#373](https://github.com/matrix-org/sygnal/issues/373))
+- Switch over to use poetry & add lock file to version control. ([\#374](https://github.com/matrix-org/sygnal/issues/374))
+- Add manual proxy testing scripts & docs. ([\#375](https://github.com/matrix-org/sygnal/issues/375))
+- Bump `black` from 23.9.1 to 24.3.0. ([\#376](https://github.com/matrix-org/sygnal/issues/376))
+- Bump `requests` from 2.31.0 to 2.32.2. ([\#377](https://github.com/matrix-org/sygnal/issues/377))
+
+
 # Sygnal 0.14.1 (2024-04-09)
 
 ### Bugfixes

--- a/changelog.d/370.doc
+++ b/changelog.d/370.doc
@@ -1,1 +1,0 @@
-Update docs & tests to reflect APNs usage in FCM v1 API.

--- a/changelog.d/372.feature
+++ b/changelog.d/372.feature
@@ -1,1 +1,0 @@
-FCM v1: use async version of google-auth and add HTTP proxy support.

--- a/changelog.d/373.misc
+++ b/changelog.d/373.misc
@@ -1,1 +1,0 @@
-Update docker build and CI workflows to Python 3.11.

--- a/changelog.d/374.misc
+++ b/changelog.d/374.misc
@@ -1,1 +1,0 @@
-Switch over to use poetry & add lock file to version control.

--- a/changelog.d/375.misc
+++ b/changelog.d/375.misc
@@ -1,1 +1,0 @@
-Add manual proxy testing scripts & docs.

--- a/changelog.d/376.misc
+++ b/changelog.d/376.misc
@@ -1,1 +1,0 @@
-Bump `black` from 23.9.1 to 24.3.0.

--- a/changelog.d/377.misc
+++ b/changelog.d/377.misc
@@ -1,1 +1,0 @@
-Bump `requests` from 2.31.0 to 2.32.2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sygnal"
-version = "0.14.1"
+version = "0.14.2"
 description = "Reference Push Gateway for Matrix Notifications"
 authors = ["Matrix.org Team and Contributors <packages@matrix.org>"]
 readme = "README.md"


### PR DESCRIPTION
New release. Primary change is fixing proxy support in the gcm pushkin when using the new firebase v1 API.