### PR TITLE
Don't delete android notification options specified in config

### DIFF
--- a/changelog.d/380.bugfix
+++ b/changelog.d/380.bugfix
@@ -1,0 +1,1 @@
+Don't delete android notification options specified in config.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -574,7 +574,10 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                 body["priority"] = "normal" if n.prio == "low" else "high"
             elif self.api_version is APIVersion.V1:
                 priority = {"priority": "normal" if n.prio == "low" else "high"}
-                body["android"] = priority
+                if "android" in body:
+                    body["android"].update(priority)
+                else:
+                    body["android"] = priority
 
             for retry_number in range(0, MAX_TRIES):
                 if self.api_version is APIVersion.Legacy:

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -174,6 +174,13 @@ class GcmTestCase(testutils.TestCase):
             "project_id": "example_project",
             "service_account_file": self.service_account_file.name,
             "fcm_options": {
+                "android": {
+                    "notification": {
+                        "body": {
+                            "test body",
+                        },
+                    },
+                },
                 "apns": {
                     "payload": {
                         "aps": {
@@ -286,7 +293,14 @@ class GcmTestCase(testutils.TestCase):
                         "unread": "2",
                         "missed_calls": "1",
                     },
-                    "android": {"priority": "high"},
+                    "android": {
+                        "notification": {
+                            "body": {
+                                "test body",
+                            },
+                        },
+                        "priority": "high",
+                    },
                     "apns": {
                         "payload": {
                             "aps": {


### PR DESCRIPTION
With the new FCM v1 api, you can add android specific notification options.
The way the priority value was being added led to any android options specified in the config file being overridden.

This changes that behaviour to ensure they are kept if present.