### PR TITLE
Truncate large values inside of Firebase notification body fields.

### DIFF
--- a/changelog.d/386.bugfix
+++ b/changelog.d/386.bugfix
@@ -1,1 +1,1 @@
-Truncate large values inside of Firebase notification body fields.
+Truncate large values inside of Firebase notification content fields.

--- a/changelog.d/386.bugfix
+++ b/changelog.d/386.bugfix
@@ -1,0 +1,1 @@
+Truncate large values inside of Firebase notification body fields.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -745,12 +745,26 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         return data
 
 
-def truncate_str(input: str, max_length: int) -> tuple[str, bool]:
+def truncate_str(input: str, max_bytes: int) -> tuple[str, bool]:
+    """
+    Truncate the given string. If the truncation would occur in the middle of a unicode
+    character, that character will be removed entirely instead.
+    Appends a `…` character to imply the string was truncated.
+
+    Args:
+        `input`: the string to be truncated
+        `max_bytes`: maximum length, in bytes, that the payload should occupy when truncated
+
+    Returns:
+        Tuple of (truncated string, whether truncation took place)
+
+    """
+
     str_bytes = input.encode("utf-8")
-    if len(str_bytes) <= max_length:
+    if len(str_bytes) <= max_bytes:
         return (input, False)
 
     try:
-        return (str_bytes[: max_length - 3].decode("utf-8") + "…", True)
+        return (str_bytes[: max_bytes - 3].decode("utf-8") + "…", True)
     except UnicodeDecodeError as err:
         return (str_bytes[: err.start].decode("utf-8") + "…", True)

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -745,7 +745,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         return data
 
 
-def truncate_str(input: str, max_bytes: int) -> tuple[str, bool]:
+def truncate_str(input: str, max_bytes: int) -> Tuple[str, bool]:
     """
     Truncate the given string. If the truncation would occur in the middle of a unicode
     character, that character will be removed entirely instead.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -707,6 +707,8 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                 for attr, value in data["content"].items():
                     if not isinstance(value, str):
                         continue
+                    if len(value) > MAX_BYTES_PER_FIELD:
+                        value = value[0:MAX_BYTES_PER_FIELD]
                     data["content_" + attr] = value
                 del data["content"]
 

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -749,7 +749,7 @@ def truncate_str(input: str, max_bytes: int) -> tuple[str, bool]:
     """
     Truncate the given string. If the truncation would occur in the middle of a unicode
     character, that character will be removed entirely instead.
-    Appends a `…` character to imply the string was truncated.
+    Appends a `…` character to the resulting string when truncation occurs.
 
     Args:
         `input`: the string to be truncated

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -716,7 +716,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                         continue
                     if len(value) > MAX_BYTES_PER_FIELD:
                         overflow_fields += 1
-                        value = value[:MAX_BYTES_PER_FIELD-3] + "…"
+                        value = value[: MAX_BYTES_PER_FIELD - 3] + "…"
                     data["content_" + attr] = value
                 del data["content"]
 

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -708,7 +708,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                     if not isinstance(value, str):
                         continue
                     if len(value) > MAX_BYTES_PER_FIELD:
-                        value = value[0 : MAX_BYTES_PER_FIELD - 3] + "..."
+                        value = value[0:MAX_BYTES_PER_FIELD] + "..."
                     data["content_" + attr] = value
                 del data["content"]
 

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -716,7 +716,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                         continue
                     if len(value) > MAX_BYTES_PER_FIELD:
                         overflow_fields += 1
-                        value = value[0:MAX_BYTES_PER_FIELD] + "..."
+                        value = value[:MAX_BYTES_PER_FIELD-3] + "…"
                     data["content_" + attr] = value
                 del data["content"]
 

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -708,7 +708,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                     if not isinstance(value, str):
                         continue
                     if len(value) > MAX_BYTES_PER_FIELD:
-                        value = value[0:MAX_BYTES_PER_FIELD]
+                        value = value[0 : MAX_BYTES_PER_FIELD - 3] + "..."
                     data["content_" + attr] = value
                 del data["content"]
 

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -757,7 +757,6 @@ def truncate_str(input: str, max_bytes: int) -> tuple[str, bool]:
 
     Returns:
         Tuple of (truncated string, whether truncation took place)
-
     """
 
     str_bytes = input.encode("utf-8")

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -548,7 +548,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
-ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooox...",
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxx...",
                         "room_id": "!slw48wfj34rtnrf:example.com",
                         "prio": "high",
                         "unread": "2",

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -548,7 +548,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
-ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxx...",
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooox…",
                         "room_id": "!slw48wfj34rtnrf:example.com",
                         "prio": "high",
                         "unread": "2",

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -528,7 +528,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
-ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxx",
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooox…",
                         "room_alias": "#exampleroom:matrix.org",
                         "membership": None,
                         "sender_display_name": "Major Tom",
@@ -548,7 +548,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
-ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooox…",
+ooooooooooxxxxxxxxxx🦉oooooo£xxxxxxxx☻oo🦉…",
                         "room_id": "!slw48wfj34rtnrf:example.com",
                         "prio": "high",
                         "unread": "2",

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -484,7 +484,7 @@ class GcmTestCase(testutils.TestCase):
     def test_api_v1_large_fields(self) -> None:
         """
         Tests the gcm pushkin truncates unusually large fields. Includes large
-        fields both at the top level of `data`, and nested within `body`.
+        fields both at the top level of `data`, and nested within `content`.
         """
         self.apns_pushkin_snotif = MagicMock()
         gcm = self.get_test_pushkin("com.example.gcm.apiv1")

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -548,7 +548,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
-ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxx",
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooox...",
                         "room_id": "!slw48wfj34rtnrf:example.com",
                         "prio": "high",
                         "unread": "2",

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -136,6 +136,96 @@ class TestCase(unittest.TestCase):
             }
         }
 
+    def _make_dummy_notification_large_fields(self, devices):
+        return {
+            "notification": {
+                "id": "$3957tyerfgewrf384",
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "type": "m.room.message",
+                "sender": "@exampleuser:matrix.org",
+                "sender_display_name": "Major Tom",
+                "room_name": "xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo",
+                "room_alias": "#exampleroom:matrix.org",
+                "prio": "high",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "I'm floating in a most peculiar way.",
+                    "other": "xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
+ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo",
+                },
+                "counts": {"unread": 2, "missed_calls": 1},
+                "devices": devices,
+            }
+        }
+
     def _request(self, payload: Union[str, dict]) -> Union[dict, int]:
         """
         Make a dummy request to the notify endpoint with the specified payload

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -136,6 +136,10 @@ class TestCase(unittest.TestCase):
             }
         }
 
+    # NOTE: The `⚑` character (len 3 bytes) is inserted at byte position 1020 (occupying 1020-1022).
+    # This will make the truncation (which is `str[: 1024 - 3]`) occur in the middle of a unicode
+    # character. The truncation logic should recognize this and return the string starting before
+    # the `⚑`, with a `…` appended to indicate the string was truncated.
     def _make_dummy_notification_large_fields(self, devices):
         return {
             "notification": {
@@ -199,7 +203,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
-ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
+ooooooooooxxxxxxxxxx🦉oooooo£xxxxxxxx☻oo🦉⚑xxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\
 ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo\
 xxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxx\


### PR DESCRIPTION
This PR changes the use of the Firebase v1 API to truncate the `content` fields within `data` to a maximum length.

NOTE: The existing code for the legacy API does not effectively truncate `content` since it relies on `len(data[attr]) > MAX_BYTES_PER_FIELD` which will return the number of keys inside the `content` dict. Since the legacy API is being removed tomorrow, I don't want to spend time coming up with a solution for this. At first glance it appears to be more involved than I would like to accurately count the size in bytes of the contents of the values inside of a python dict.