### PR TITLE
remove real name requirement from DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,11 +248,6 @@ include the line in your commit or pull request comment:
 Signed-off-by: Your Name <your@email.example.org>
 ```
 
-We accept contributions under a legally identifiable name, such as
-your name on government documentation or common-law names (names
-claimed by legitimate usage or repute). Unfortunately, we cannot
-accept anonymous contributions at this time.
-
 Git allows you to add this signoff automatically when using the `-s`
 flag to `git commit`, which uses the name and email set in your
 `user.name` and `user.email` git configs.


### PR DESCRIPTION
Removing real name requirement from the DCO in line with updated Foundation policies.

Opening the PR to get a # which I'll incorporate in a follow up commit for the changelog fragment.