### PR TITLE
Only allow aiohttp < 3.10.0

### DIFF
--- a/changelog.d/394.bugfix
+++ b/changelog.d/394.bugfix
@@ -1,0 +1,1 @@
+Only allow aiohttp < 3.10.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8.0"
 aioapns = ">=3.0"
-aiohttp = ">=3.8.0"
+aiohttp = ">=3.8.0,<3.10.0"
 attrs = ">=19.2.0"
 cryptography = ">=2.6.1"
 idna = ">=2.8"


### PR DESCRIPTION
Newer versions of aiohttp break Sygnal when using FCM + proxy. Since aiohttp>=3.10, the following error occurs: `RuntimeError: no running event loop`. IIUC, this is because Sygnal is [using aiohttp incorrectly](https://github.com/matrix-org/sygnal/blob/345aa61a59cebc2b87a7375ab696838f98e37097/sygnal/gcmpushkin.py#L217).

Downstream bug (German): https://gitlab.opencode.de/bwi/bundesmessenger/backend/helm-chart/-/issues/40
