### PR TITLE
Fix breakage with `aiohttp>=3.10.0` when using GCM and an HTTP proxy

### DIFF
--- a/changelog.d/395.bugfix
+++ b/changelog.d/395.bugfix
@@ -1,0 +1,1 @@
+Fix incompatibility with `aiohttp>=3.10.0` when using GCM with an HTTP proxy.

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -239,6 +239,9 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             # `ClientSession` can't directly take the proxy URL, so we need to
             # set the usual env var and use `trust_env=True`
             os.environ["HTTPS_PROXY"] = proxy_url
+
+            # ClientSession must be instantiated by an async function, hence we do this
+            # here instead of `__init__`.
             session = aiohttp.ClientSession(trust_env=True, auto_decompress=False)
 
         cls.google_auth_request = google.auth.transport._aiohttp_requests.Request(

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -155,13 +155,13 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         tls_client_options_factory = ClientTLSOptionsFactory()
 
         # use the Sygnal global proxy configuration
-        proxy_url = sygnal.config.get("proxy")
+        self.proxy_url = sygnal.config.get("proxy")
 
         self.http_agent = ProxyAgent(
             reactor=sygnal.reactor,
             pool=self.http_pool,
             contextFactory=tls_client_options_factory,
-            proxy_url_str=proxy_url,
+            proxy_url_str=self.proxy_url,
         )
 
         self.api_version = APIVersion.Legacy
@@ -209,16 +209,10 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
                     f"`service_account_file` must be valid: {str(e)}",
                 )
 
-            session = None
-            if proxy_url:
-                # `ClientSession` can't directly take the proxy URL, so we need to
-                # set the usual env var and use `trust_env=True`
-                os.environ["HTTPS_PROXY"] = proxy_url
-                session = aiohttp.ClientSession(trust_env=True, auto_decompress=False)
-
-            self.google_auth_request = google.auth.transport._aiohttp_requests.Request(
-                session=session
-            )
+        # This is built in `_refresh_credentials`, and must be done in an async function.
+        self.google_auth_request: Optional[
+            google.auth.transport._aiohttp_requests.Request
+        ] = None
 
         # Use the fcm_options config dictionary as a foundation for the body;
         # this lets the Sygnal admin choose custom FCM options
@@ -513,11 +507,29 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
     async def _refresh_credentials(self) -> None:
         assert self.credentials is not None
         if not self.credentials.valid:
+            # Setting up a ClientSession must be done from an async function.
+            # Lazily build `self.google_auth_request` instead of doing so in `__init__`.
+            if self.google_auth_request is None:
+                self.google_auth_request = await self._build_google_auth_request()
+
             await Deferred.fromFuture(
                 asyncio.ensure_future(
                     self.credentials.refresh(self.google_auth_request)
                 )
             )
+
+    async def _build_google_auth_request(
+        self,
+    ) -> google.auth.transport._aiohttp_requests.Request:
+        """Build a google auth request with an HTTP proxy, if configured."""
+        session = None
+        if self.proxy_url:
+            # `ClientSession` can't directly take the proxy URL, so we need to
+            # set the usual env var and use `trust_env=True`
+            os.environ["HTTPS_PROXY"] = self.proxy_url
+            session = aiohttp.ClientSession(trust_env=True, auto_decompress=False)
+
+        return google.auth.transport._aiohttp_requests.Request(session=session)
 
     async def _dispatch_notification_unlimited(
         self, n: Notification, device: Device, context: NotificationContext

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -132,8 +132,6 @@ class TestGcmPushkin(GcmPushkin):
     async def _refresh_credentials(self) -> None:
         assert self.credentials is not None
         if not self.credentials.valid:
-            if self.google_auth_request is None:
-                self.google_auth_request = await self._build_google_auth_request()
             await self.credentials.refresh(self.google_auth_request)
 
 

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -132,6 +132,8 @@ class TestGcmPushkin(GcmPushkin):
     async def _refresh_credentials(self) -> None:
         assert self.credentials is not None
         if not self.credentials.valid:
+            if self.google_auth_request is None:
+                self.google_auth_request = await self._build_google_auth_request()
             await self.credentials.refresh(self.google_auth_request)
 
 


### PR DESCRIPTION
Since `aiohttp==3.10.0`, instantiating `aiohttp.ClientSession` must be done from an async function. Calling this from a non-async function relied on deprecated behaviour in Python, which broke in recent releases. https://github.com/aio-libs/aiohttp/issues/8555#issuecomment-2263814747 explains the situation.

We would do this when using GCM + an HTTP proxy:

https://github.com/matrix-org/sygnal/blob/345aa61a59cebc2b87a7375ab696838f98e37097/sygnal/gcmpushkin.py#L213-L217

Rather than pin `aiohttp` to an older version, let's just fix the behaviour. Supersedes https://github.com/matrix-org/sygnal/pull/394.