### PR TITLE
Pin `aiohttp` to <= 4.0.0

### DIFF
--- a/changelog.d/396.misc
+++ b/changelog.d/396.misc
@@ -1,0 +1,1 @@
+Pin `aiohttp` dependency to <= 4.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8.0"
 aioapns = ">=3.0"
-aiohttp = ">=3.8.0"
+aiohttp = "^3.8.0"
 attrs = ">=19.2.0"
 cryptography = ">=2.6.1"
 idna = ">=2.8"


### PR DESCRIPTION
To prevent accidentally upgrading past 4.0.0 and incurring breaking changes.