### PR TITLE
Upgrade docker/build-push-action from v2 to v6 in workflows

### DIFF
--- a/.github/workflows/docker_check.yml
+++ b/.github/workflows/docker_check.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build all platforms
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and push all platforms
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/changelog.d/411.feature
+++ b/changelog.d/411.feature
@@ -1,0 +1,1 @@
+Upgrade docker/build-push-action from v2 to v6 in workflows


### PR DESCRIPTION
Fix warning when building the image:

```
 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 15)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 48)
 - UndefinedVar: Usage of undefined variable '$CARGO_HOME' (line 70)
```

![Screenshot 2025-05-09 at 10 33 57 am](https://github.com/user-attachments/assets/ada4dcae-1b87-4d93-ae4f-3e7d6cdba37d)
