### PR TITLE
Fix warning messages when calculating docker image tags

### DIFF
--- a/.github/workflows/docker_check.yml
+++ b/.github/workflows/docker_check.yml
@@ -8,8 +8,8 @@ name: Check Docker image can be built successfully
 on:
   push:
     paths:
-      - 'docker/Dockerfile'
-      - '.github/workflows/docker_check.yml'
+      - "docker/Dockerfile"
+      - ".github/workflows/docker_check.yml"
 
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build all platforms
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/.github/workflows/docker_check.yml
+++ b/.github/workflows/docker_check.yml
@@ -8,8 +8,8 @@ name: Check Docker image can be built successfully
 on:
   push:
     paths:
-      - "docker/Dockerfile"
-      - ".github/workflows/docker_check.yml"
+      - 'docker/Dockerfile'
+      - '.github/workflows/docker_check.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Calculate docker image tags
         id: set-tag
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: matrixdotorg/sygnal
           tags: |
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and push all platforms
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/changelog.d/412.misc
+++ b/changelog.d/412.misc
@@ -1,0 +1,1 @@
+Bump docker/build-push-action and docker/metadata-action to the latest versions.


### PR DESCRIPTION
Fix warning in GitHub Actions.

![Screenshot 2025-05-09 at 10 27 26 am](https://github.com/user-attachments/assets/24c25428-3aec-4e83-97b1-858282f97d3f)
