### PR TITLE
fix: Pin aioapns to <4.0 to fix breaking change

### DIFF
--- a/changelog.d/417.bugfix
+++ b/changelog.d/417.bugfix
@@ -1,0 +1,1 @@
+Pin aioapns to  be older than v4.0 to avoid a breaking change in key handling. Contributed by Michael DiStefano.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8.0"
-aioapns = ">=3.0"
+aioapns = ">=3.0,<4.0"
 aiohttp = "^3.10.11"
 attrs = ">=19.2.0"
 cryptography = ">=2.6.1"


### PR DESCRIPTION
This PR fixes an issue where APNS push notifications fail with a `MalformedFraming` error when Sygnal is installed in an environment with `aioapns>=4.0`.

The root cause is a breaking change introduced in `aioapns` v4.0, where the `key` parameter for the `APNs` class now expects the raw key content instead of a file path. Sygnal v0.15.1 was released prior to this change and still passes a file path, causing the `jwt` library to fail when trying to prepare the key.

This change pins the `aioapns` dependency to `<4.0` to ensure that a compatible version is used, resolving the issue and restoring APNS functionality.