### PR TITLE
Add HEALTHCHECK directive to the Dockerfile

### DIFF
--- a/changelog.d/418.docker
+++ b/changelog.d/418.docker
@@ -1,1 +1,1 @@
-Add HEALTHCHECK directive to the container image, using existing `/health` endpoint.
+Add `HEALTHCHECK` directive to the container image, using existing `/health` endpoint.

--- a/changelog.d/418.docker
+++ b/changelog.d/418.docker
@@ -1,0 +1,1 @@
+Add HEALTHCHECK directive to the container image, using existing `/health` endpoint.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,3 +97,6 @@ COPY --from=builder /install /usr/local
 EXPOSE 5000/tcp
 
 ENTRYPOINT ["python", "-m", "sygnal.sygnal"]
+
+HEALTHCHECK --start-period=25s --interval=15s --timeout=5s \
+  CMD curl --fail --silent --show-error http://localhost:5000/health || exit 1


### PR DESCRIPTION
Tested against `podman` (running `podman compose` flow from https://github.com/matrix-org/sygnal/pull/413). Verified that it reports as 'healthy'.

The endpoint was introduced in https://github.com/matrix-org/sygnal/pull/55 (Sygnal 0.2.3).